### PR TITLE
Add UNHCR/HDX ingestion and Bayesian explainability

### DIFF
--- a/preact/dashboard/app.py
+++ b/preact/dashboard/app.py
@@ -23,6 +23,16 @@ def load_predictions(path: Path) -> Dict[str, pd.Series]:
     return predictions
 
 
+def load_bayesian_evidence(path: Path) -> pd.DataFrame | None:
+    evidence_file = path / "bayesian_evidence.json"
+    if not evidence_file.exists():
+        return None
+    frame = pd.read_json(evidence_file)
+    if frame.empty:
+        return None
+    return frame
+
+
 def main(prediction_dir: str, outcomes_path: str | None = None) -> None:
     st.sidebar.header("Data Inputs")
     prediction_path = Path(prediction_dir)
@@ -45,6 +55,11 @@ def main(prediction_dir: str, outcomes_path: str | None = None) -> None:
     st.subheader("Latest Alerts")
     ranking = pd.Series(latest).sort_values(ascending=False)
     st.bar_chart(ranking)
+
+    evidence = load_bayesian_evidence(prediction_path)
+    if evidence is not None:
+        st.subheader("Bayesian Evidence Snapshot")
+        st.dataframe(evidence)
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/preact/data_ingestion/__init__.py
+++ b/preact/data_ingestion/__init__.py
@@ -3,7 +3,9 @@ from .sources import (
     ACLEDSource,
     DataSource,
     GDELTSource,
+    HDXSource,
     SyntheticEconomicSource,
+    UNHCRSource,
     build_sources,
     fetch_all,
 )
@@ -12,7 +14,9 @@ __all__ = [
     "ACLEDSource",
     "DataSource",
     "GDELTSource",
+    "HDXSource",
     "SyntheticEconomicSource",
+    "UNHCRSource",
     "build_sources",
     "fetch_all",
 ]

--- a/preact/models/__init__.py
+++ b/preact/models/__init__.py
@@ -1,5 +1,12 @@
 """Predictive models for PREACT."""
+from .bayesian import BayesianEvidence, BayesianExplainer
 from .predictor import ModelOutput, PredictiveEngine, rolling_backtest
 
-__all__ = ["ModelOutput", "PredictiveEngine", "rolling_backtest"]
+__all__ = [
+    "BayesianEvidence",
+    "BayesianExplainer",
+    "ModelOutput",
+    "PredictiveEngine",
+    "rolling_backtest",
+]
 

--- a/preact/models/bayesian.py
+++ b/preact/models/bayesian.py
@@ -1,0 +1,138 @@
+"""Bayesian explainability utilities for PREACT."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class BayesianEvidence:
+    """Evidence summary for a single feature bucket."""
+
+    feature: str
+    bucket: str
+    posterior: float
+    likelihood_ratio: float
+    evidence_strength: str
+    samples: int
+
+
+class BayesianExplainer:
+    """Naive Bayesian evidence aggregation for calibrated model outputs."""
+
+    def __init__(self, prior: float = 0.05, smoothing: float = 1.0, bins: int = 4) -> None:
+        if not 0 < prior < 1:
+            raise ValueError("Prior must be within (0, 1)")
+        if bins < 2:
+            raise ValueError("At least two bins are required for Bayesian explanations")
+        self.prior = prior
+        self.smoothing = smoothing
+        self.bins = bins
+
+    def explain(self, features: pd.DataFrame, target: pd.Series) -> pd.DataFrame:
+        """Return Bayesian evidence for the latest observation per feature."""
+
+        if features.empty:
+            return pd.DataFrame(columns=BayesianEvidence.__dataclass_fields__.keys())
+
+        aligned_target = target.reindex(features.index).fillna(0).astype(int)
+        prior_odds = self.prior / (1 - self.prior)
+        evidences: List[Dict[str, object]] = []
+
+        latest_index = features.index[-1]
+        for column in features.columns:
+            raw = pd.to_numeric(features[column], errors="coerce")
+            series = raw.dropna()
+            if series.empty or series.nunique() < 2:
+                continue
+            try:
+                categories, bin_edges = pd.qcut(
+                    series,
+                    q=min(self.bins, series.nunique()),
+                    labels=False,
+                    retbins=True,
+                    duplicates="drop",
+                )
+            except ValueError:
+                continue
+            bin_assignment = pd.Series(categories, index=series.index)
+            if latest_index not in bin_assignment.index:
+                # Attempt to use the closest prior observation
+                available = bin_assignment.index[bin_assignment.index <= latest_index]
+                available = available.sort_values()
+                if len(available) == 0:
+                    continue
+                latest_bin = int(bin_assignment.loc[available[-1]])
+            else:
+                latest_bin = int(bin_assignment.loc[latest_index])
+
+            df = pd.DataFrame(
+                {
+                    "bin": bin_assignment,
+                    "event": aligned_target.reindex(bin_assignment.index).fillna(0).astype(int),
+                }
+            )
+            counts = df.groupby("bin")["event"].agg(["sum", "count"])
+            if latest_bin not in counts.index:
+                continue
+            summary = counts.loc[latest_bin]
+            event_count = float(summary["sum"])
+            total = float(summary["count"])
+            posterior = (event_count + self.smoothing * self.prior) / (
+                total + self.smoothing
+            )
+            posterior = float(np.clip(posterior, 1e-6, 1 - 1e-6))
+            odds = posterior / (1 - posterior)
+            likelihood_ratio = float(odds / prior_odds)
+            evidence_strength = self._describe_strength(likelihood_ratio)
+            bucket_label = self._format_bucket(bin_edges, latest_bin)
+
+            evidences.append(
+                {
+                    "feature": column,
+                    "bucket": bucket_label,
+                    "posterior": posterior,
+                    "likelihood_ratio": likelihood_ratio,
+                    "evidence_strength": evidence_strength,
+                    "samples": int(total),
+                }
+            )
+
+        if not evidences:
+            return pd.DataFrame(columns=BayesianEvidence.__dataclass_fields__.keys())
+
+        frame = pd.DataFrame(evidences)
+        return frame.sort_values("posterior", ascending=False).reset_index(drop=True)
+
+    def _format_bucket(self, edges: np.ndarray, index: int) -> str:
+        lower = edges[index]
+        upper = edges[min(index + 1, len(edges) - 1)]
+        if np.isinf(lower) and np.isinf(upper):
+            return "all values"
+        if np.isinf(lower):
+            return f"<= {upper:.2f}"
+        if np.isinf(upper):
+            return f"> {lower:.2f}"
+        return f"[{lower:.2f}, {upper:.2f})"
+
+    def _describe_strength(self, likelihood_ratio: float) -> str:
+        if likelihood_ratio >= 10:
+            return "very strong increase"
+        if likelihood_ratio >= 3:
+            return "strong increase"
+        if likelihood_ratio >= 1.5:
+            return "moderate increase"
+        if likelihood_ratio >= 1.1:
+            return "slight increase"
+        if likelihood_ratio <= 0.1:
+            return "very strong decrease"
+        if likelihood_ratio <= 0.33:
+            return "strong decrease"
+        if likelihood_ratio <= 0.66:
+            return "moderate decrease"
+        if likelihood_ratio <= 0.9:
+            return "slight decrease"
+        return "neutral"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_bayesian.py
+++ b/tests/test_bayesian.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from preact.models.bayesian import BayesianExplainer
+
+
+def test_bayesian_explainer_returns_evidence():
+    features = pd.DataFrame(
+        {
+            "events__feature": [0.1, 0.2, 0.4, 0.5],
+            "economic__feature": [1.0, 1.1, 1.2, 1.3],
+        },
+        index=pd.date_range("2023-01-01", periods=4, freq="D"),
+    )
+    target = pd.Series([0, 0, 1, 1], index=features.index)
+
+    explainer = BayesianExplainer(prior=0.2, smoothing=1.0, bins=3)
+    evidence = explainer.explain(features, target)
+
+    assert not evidence.empty
+    assert set(["feature", "posterior", "likelihood_ratio"]).issubset(evidence.columns)
+    assert evidence.iloc[0]["posterior"] >= 0


### PR DESCRIPTION
## Summary
- add UNHCR and HDX data connectors with synthetic fallbacks and register them for the ingestion pipeline
- extend the feature store and predictive engine to support humanitarian features and flattened datasets
- introduce a Bayesian explainer, surface its output in the pipeline and dashboard, and cover the new behaviour with tests

## Testing
- `pytest`
- `python scripts/update_pipeline.py --output-dir /tmp/preact-test --lookback-days 5`


------
https://chatgpt.com/codex/tasks/task_e_68d984e29dac832fb146cf4554c53706