### PR TITLE
Handle API credential injection for HTTP sources

### DIFF
--- a/preact/config.py
+++ b/preact/config.py
@@ -15,6 +15,9 @@ class DataSourceConfig:
     update_frequency: str = "daily"
     params: Dict[str, str] | None = None
     requires_key: bool = False
+    key_env_var: Optional[str] = None
+    key_param: Optional[str] = None
+    headers: Dict[str, str] | None = None
 
 
 @dataclass

--- a/preact/data_ingestion/sources.py
+++ b/preact/data_ingestion/sources.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import abc
 import json
+import os
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -70,13 +71,56 @@ class HTTPJSONSource(DataSource):
 
     def fetch(self, start: datetime, end: datetime) -> IngestionResult:
         params = self.build_params(start, end)
+        params, headers = self._apply_auth(params)
         LOGGER.info("Fetching %s from %s", self.config.name, self.config.endpoint)
-        response = requests.get(self.config.endpoint, params=params, timeout=30)
+        response = requests.get(
+            self.config.endpoint, params=params, headers=headers or None, timeout=30
+        )
         response.raise_for_status()
         payload = response.json()
         data = pd.json_normalize(payload.get("results", payload))
         metadata = self._build_metadata(params)
         return IngestionResult(data=data, metadata=metadata)
+
+    def _apply_auth(
+        self, params: MutableMapping[str, str]
+    ) -> tuple[MutableMapping[str, str], Dict[str, str] | None]:
+        headers: Dict[str, str] | None = None
+        if self.config.headers:
+            headers = dict(self.config.headers)
+
+        key_value: Optional[str] = None
+        if self.config.key_env_var:
+            key_value = os.environ.get(self.config.key_env_var)
+            if not key_value and self.config.requires_key:
+                raise RuntimeError(
+                    "API key required but environment variable "
+                    f"{self.config.key_env_var} is not set"
+                )
+        elif self.config.requires_key:
+            raise RuntimeError(
+                "Data source requires an API key but no key_env_var was provided"
+            )
+
+        if key_value:
+            if self.config.key_param:
+                params.setdefault(self.config.key_param, key_value)
+            else:
+                inserted = False
+                if headers is None:
+                    headers = {}
+                updated_headers: Dict[str, str] = {}
+                for name, value in headers.items():
+                    if "{key}" in value:
+                        updated_headers[name] = value.format(key=key_value)
+                        inserted = True
+                    else:
+                        updated_headers[name] = value
+                headers = updated_headers
+                if not inserted:
+                    headers.setdefault("Authorization", key_value)
+
+        return params, headers
 
 
 class GDELTSource(HTTPJSONSource):
@@ -122,9 +166,15 @@ class GDELTSource(HTTPJSONSource):
 
     def fetch(self, start: datetime, end: datetime) -> IngestionResult:
         params = self.build_params(start, end)
+        params, headers = self._apply_auth(params)
         metadata = self._build_metadata(params)
         try:
-            response = requests.get(self.config.endpoint, params=params, timeout=30)
+            response = requests.get(
+                self.config.endpoint,
+                params=params,
+                headers=headers or None,
+                timeout=30,
+            )
             response.raise_for_status()
             tidy = self._normalise(response.json(), start, end)
             metadata["fallback"] = "false"
@@ -186,9 +236,15 @@ class ACLEDSource(HTTPJSONSource):
 
     def fetch(self, start: datetime, end: datetime) -> IngestionResult:
         params = self.build_params(start, end)
+        params, headers = self._apply_auth(params)
         metadata = self._build_metadata(params)
         try:
-            response = requests.get(self.config.endpoint, params=params, timeout=30)
+            response = requests.get(
+                self.config.endpoint,
+                params=params,
+                headers=headers or None,
+                timeout=30,
+            )
             response.raise_for_status()
             tidy = self._normalise(response.json(), start, end)
             metadata["fallback"] = "false"
@@ -283,9 +339,15 @@ class UNHCRSource(HTTPJSONSource):
 
     def fetch(self, start: datetime, end: datetime) -> IngestionResult:
         params = self.build_params(start, end)
+        params, headers = self._apply_auth(params)
         metadata = self._build_metadata(params)
         try:
-            response = requests.get(self.config.endpoint, params=params, timeout=30)
+            response = requests.get(
+                self.config.endpoint,
+                params=params,
+                headers=headers or None,
+                timeout=30,
+            )
             response.raise_for_status()
             tidy = self._normalise(response.json(), start, end)
             metadata["fallback"] = "false"
@@ -357,9 +419,15 @@ class HDXSource(HTTPJSONSource):
 
     def fetch(self, start: datetime, end: datetime) -> IngestionResult:
         params = self.build_params(start, end)
+        params, headers = self._apply_auth(params)
         metadata = self._build_metadata(params)
         try:
-            response = requests.get(self.config.endpoint, params=params, timeout=30)
+            response = requests.get(
+                self.config.endpoint,
+                params=params,
+                headers=headers or None,
+                timeout=30,
+            )
             response.raise_for_status()
             tidy = self._normalise(response.json(), start, end)
             metadata["fallback"] = "false"

--- a/scripts/update_pipeline.py
+++ b/scripts/update_pipeline.py
@@ -33,12 +33,27 @@ logging.basicConfig(level=logging.INFO)
 def default_config(root: Path) -> PREACTConfig:
     data_sources = [
         DataSourceConfig(name="GDELT", endpoint="https://api.gdeltproject.org/api/v2/events"),
-        DataSourceConfig(name="ACLED", endpoint="https://api.acleddata.com/acled/read"),
-        DataSourceConfig(name="UNHCR", endpoint="https://api.unhcr.org/population/v1/population"),
+        DataSourceConfig(
+            name="ACLED",
+            endpoint="https://api.acleddata.com/acled/read",
+            requires_key=True,
+            key_env_var="ACLED_API_TOKEN",
+            key_param="key",
+        ),
+        DataSourceConfig(
+            name="UNHCR",
+            endpoint="https://api.unhcr.org/population/v1/population",
+            requires_key=True,
+            key_env_var="UNHCR_API_TOKEN",
+            headers={"Authorization": "Bearer {key}"},
+        ),
         DataSourceConfig(
             name="HDX",
             endpoint="https://data.humdata.org/hxlproxy/data/download",
             params={"format": "json"},
+            requires_key=True,
+            key_env_var="HDX_API_TOKEN",
+            headers={"Authorization": "Bearer {key}"},
         ),
         DataSourceConfig(name="Synthetic_Economic", endpoint="synthetic"),
     ]


### PR DESCRIPTION
## Summary
- extend `DataSourceConfig` to accept optional authentication settings for HTTP data sources
- update `HTTPJSONSource` and subclasses to inject API keys from environment variables into request params or headers
- mark credentialed sources in the default pipeline configuration with their expected environment variables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db8daf2d8c832f852decf92b39fb94