### PR TITLE
Add notebook for testing configured data sources

### DIFF
--- a/notebooks/data_source_sanity_checks.ipynb
+++ b/notebooks/data_source_sanity_checks.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Verifica delle fonti dati\n",
+    "\n",
+    "Questo notebook permette di testare rapidamente il recupero dei dati dalle principali fonti configurate nel progetto PREACT.\n",
+    "\n",
+    "> ℹ️ La configurazione completa include cinque connettori (`GDELT`, `ACLED`, `UNHCR`, `HDX`, `Economic_Indicators`). Qui concentriamo gli esempi sulle tre fonti più utilizzate nel flusso base (eventi da **GDELT**, conflitti da **ACLED** ed indicatori macro-economici dalla **World Bank**)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import dei moduli necessari"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "import os\n",
+    "\n",
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from preact.config import DataSourceConfig\n",
+    "from preact.data_ingestion.sources import build_sources, fetch_all"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configurazione delle credenziali\n",
+    "\n",
+    "Le API di ACLED possono essere consultate solo dopo registrazione, mentre alcune chiamate UNHCR/HDX richiedono un bearer token. Impostiamo qui dei segnaposto (`xxxxx`) così da avere ben chiari i parametri da sostituire con le chiavi reali ottenute in fase di registrazione."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ.setdefault(\"ACLED_API_TOKEN\", \"xxxxx\")\n",
+    "os.environ.setdefault(\"UNHCR_API_TOKEN\", \"xxxxx\")\n",
+    "os.environ.setdefault(\"HDX_API_TOKEN\", \"xxxxx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Definizione delle fonti da testare\n",
+    "\n",
+    "Per ciascuna fonte definiamo il relativo `DataSourceConfig`. È possibile modificare facilmente parametri, intervalli temporali e chiavi prima di eseguire il notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_configs = [\n",
+    "    DataSourceConfig(\n",
+    "        name=\"GDELT\",\n",
+    "        endpoint=\"https://api.gdeltproject.org/api/v2/events\",\n",
+    "    ),\n",
+    "    DataSourceConfig(\n",
+    "        name=\"ACLED\",\n",
+    "        endpoint=\"https://api.acleddata.com/acled/read\",\n",
+    "        requires_key=True,\n",
+    "        key_env_var=\"ACLED_API_TOKEN\",\n",
+    "        key_param=\"key\",\n",
+    "    ),\n",
+    "    DataSourceConfig(\n",
+    "        name=\"Economic_Indicators\",\n",
+    "        endpoint=\"https://api.worldbank.org/v2/country/{country}/indicator/{indicator}\",\n",
+    "        params={\n",
+    "            \"country\": \"WLD\",\n",
+    "            \"indicators\": \"FP.CPI.TOTL.ZG,NY.GDP.MKTP.KD.ZG\",\n",
+    "            \"aliases\": \"{\\\"FP.CPI.TOTL.ZG\\\": \\\"inflation_rate\\\", \\\"NY.GDP.MKTP.KD.ZG\\\": \\\"gdp_growth\\\"}\",\n",
+    "            \"per_page\": \"2000\",\n",
+    "        },\n",
+    "    ),\n",
+    "]\n",
+    "sources = build_sources(source_configs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download dei dati di esempio\n",
+    "\n",
+    "Di default vengono recuperati gli ultimi 14 giorni. È possibile modificare `lookback_days` o la data di fine (`end_date`) secondo necessità."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lookback_days = 14\n",
+    "end_date = datetime.utcnow()\n",
+    "\n",
+    "results = fetch_all(sources, lookback_days=lookback_days, end=end_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Esplorazione rapida dei risultati\n",
+    "\n",
+    "Per ogni fonte mostriamo le prime righe del dataset restituito e la relativa metainformazione di ingestione (timestamp, range temporale, uso di fallback ecc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, result in results.items():\n",
+    "    if result is None:\n",
+    "        print(f\"⚠️ {name}: nessun risultato disponibile\")\n",
+    "        continue\n",
+    "    print(f\"=== {name} ===\")\n",
+    "    display(result.data.head())\n",
+    "    display(pd.DataFrame([result.metadata]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prossimi passi\n",
+    "\n",
+    "* Sostituire i valori `xxxxx` con le chiavi reali per ottenere dati autentici dalle API protette.\n",
+    "* Aumentare `lookback_days` per fetch più ampi oppure impostare `end_date` a una data storica.\n",
+    "* Salvare i dataframe con `result.data.to_parquet(...)` o `to_csv(...)` per analisi offline."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook under `notebooks/` that demonstrates how to fetch data from the configured sources
- include placeholder credential setup for protected APIs and showcase quick inspection of fetched data

## Testing
- no tests were run (notebook-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db90b8d194832fb166482dd8b01b05