### PR TITLE
Use OAuth tokens for ACLED ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ scripts/
    thresholds. Use the sidebar to adjust the alert sensitivity or load validation
    outcomes for hindcasting studies.
 
+## Data Source Authentication
+
+Several upstream providers require authenticated access. Configure the following
+environment variables before running the pipeline:
+
+- `ACLED_USERNAME` and `ACLED_PASSWORD` – credentials used to request an OAuth access
+  token from ACLED. The ingestion connector automatically exchanges them for a bearer
+  token, caches it until expiry, and refreshes it as needed. Optional
+  `ACLED_CLIENT_ID` and `ACLED_CLIENT_SECRET` variables are included in the token
+  request when present.
+- `UNHCR_API_TOKEN` – bearer token for the UNHCR Population API.
+- `HDX_API_TOKEN` – bearer token for the Humanitarian Data Exchange API.
+
+Tokens are injected as `Authorization` headers when contacting the APIs. If required
+credentials are missing, the connector raises a descriptive error so you can provide
+the appropriate values.
+
 ## Evaluation and Backtesting
 
 - Historical hindcasting on cases such as Niger 2023 (coup), Sudan 2023 (atrocities),

--- a/preact/data_ingestion/sources.py
+++ b/preact/data_ingestion/sources.py
@@ -203,12 +203,90 @@ class ACLEDSource(HTTPJSONSource):
 
     date_param = "event_date"
     end_param = "event_date_end"
+    token_endpoint = "https://acleddata.com/oauth/token"
+
+    def __init__(self, config: DataSourceConfig) -> None:
+        super().__init__(config)
+        self._access_token: str | None = None
+        self._token_expiry: datetime | None = None
 
     def build_params(self, start: datetime, end: datetime) -> MutableMapping[str, str]:
         params = super().build_params(start, end)
         params.setdefault("event_type", "Violence against civilians")
         params.setdefault("limit", "5000")
         return params
+
+    def _apply_auth(
+        self, params: MutableMapping[str, str]
+    ) -> tuple[MutableMapping[str, str], Dict[str, str] | None]:
+        headers: Dict[str, str] | None = None
+        if self.config.headers:
+            headers = dict(self.config.headers)
+
+        token = self._get_access_token()
+
+        if headers is None:
+            headers = {"Authorization": f"Bearer {token}"}
+        else:
+            inserted = False
+            updated_headers: Dict[str, str] = {}
+            for name, value in headers.items():
+                if "{key}" in value:
+                    updated_headers[name] = value.format(key=token)
+                    inserted = True
+                else:
+                    updated_headers[name] = value
+            if not inserted:
+                updated_headers.setdefault("Authorization", f"Bearer {token}")
+            headers = updated_headers
+
+        return params, headers
+
+    def _get_access_token(self) -> str:
+        now = datetime.utcnow()
+        if self._access_token and self._token_expiry and now < self._token_expiry:
+            return self._access_token
+
+        username = os.environ.get("ACLED_USERNAME")
+        password = os.environ.get("ACLED_PASSWORD")
+        if not username or not password:
+            raise RuntimeError(
+                "ACLED credentials are not configured. "
+                "Set ACLED_USERNAME and ACLED_PASSWORD environment variables."
+            )
+
+        payload: Dict[str, str] = {
+            "grant_type": "password",
+            "username": username,
+            "password": password,
+        }
+
+        client_id = os.environ.get("ACLED_CLIENT_ID")
+        if client_id:
+            payload["client_id"] = client_id
+
+        client_secret = os.environ.get("ACLED_CLIENT_SECRET")
+        if client_secret:
+            payload["client_secret"] = client_secret
+
+        response = requests.post(self.token_endpoint, data=payload, timeout=30)
+        response.raise_for_status()
+        token_payload = response.json()
+
+        token = token_payload.get("access_token")
+        if not token:
+            raise RuntimeError("ACLED OAuth response did not include an access_token")
+
+        expires_in = token_payload.get("expires_in")
+        try:
+            expires_seconds = int(expires_in)
+        except (TypeError, ValueError):
+            expires_seconds = 3600
+
+        # Refresh the token slightly before it expires to avoid race conditions.
+        self._token_expiry = now + timedelta(seconds=max(expires_seconds - 60, 60))
+        self._access_token = token
+        return token
 
     def _fallback(self, start: datetime, end: datetime) -> pd.DataFrame:
         date_range = pd.date_range(start=start, end=end, freq="D")

--- a/scripts/update_pipeline.py
+++ b/scripts/update_pipeline.py
@@ -38,8 +38,7 @@ def default_config(root: Path) -> PREACTConfig:
             name="ACLED",
             endpoint="https://api.acleddata.com/acled/read",
             requires_key=True,
-            key_env_var="ACLED_API_TOKEN",
-            key_param="key",
+            headers={"Authorization": "Bearer {key}"},
         ),
         DataSourceConfig(
             name="UNHCR",


### PR DESCRIPTION
## Summary
- update the ACLED data source configuration to use an Authorization header placeholder
- fetch and cache OAuth bearer tokens for ACLED using environment-provided credentials
- document the new ACLED credential variables alongside existing data source tokens

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db9a6975d8832fab9a32fb4c521129