### PR TITLE
feat: redesign Streamlit dashboard UX for MVP

### DIFF
--- a/preact/dashboard/app.py
+++ b/preact/dashboard/app.py
@@ -1,13 +1,25 @@
 """Streamlit dashboard for the PREACT early warning system."""
 from __future__ import annotations
 
+import sys
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 import pandas as pd
 import streamlit as st
 
-from ..evaluation.metrics import summary_table
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = PACKAGE_ROOT.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from preact.evaluation.metrics import summary_table
+from preact.dashboard.layout import render_dashboard
+from preact.dashboard.sample_data import (
+    generate_sample_evidence,
+    generate_sample_outcomes,
+    generate_sample_predictions,
+)
 
 st.set_page_config(page_title="PREACT Early Warning", layout="wide")
 st.title("PREACT – Global Early Warning Dashboard")
@@ -33,33 +45,51 @@ def load_bayesian_evidence(path: Path) -> pd.DataFrame | None:
     return frame
 
 
-def main(prediction_dir: str, outcomes_path: str | None = None) -> None:
-    st.sidebar.header("Data Inputs")
-    prediction_path = Path(prediction_dir)
-    predictions = load_predictions(prediction_path)
+def prepare_predictions(path: Path) -> Tuple[Dict[str, pd.Series], bool]:
+    """Load predictions or provide a deterministic sample fallback."""
 
-    if not predictions:
-        st.warning("No predictions found. Run the pipeline to generate outputs.")
-        return
+    predictions = load_predictions(path)
+    if predictions:
+        return predictions, False
+
+    sample_predictions = generate_sample_predictions()
+    return sample_predictions, True
+
+
+def main(prediction_dir: str, outcomes_path: str | None = None) -> None:
+    st.sidebar.header("Data inputs")
+    prediction_path = Path(prediction_dir)
+    predictions, using_sample = prepare_predictions(prediction_path)
+
+    if using_sample:
+        st.sidebar.warning(
+            "Nessun file di previsione trovato. Mostriamo dati di esempio per l'MVP."
+        )
 
     threshold = st.sidebar.slider("Alert threshold", min_value=0.1, max_value=0.9, value=0.65)
-    latest = {name: series.iloc[-1] for name, series in predictions.items()}
-    st.metric("Top Alert Probability", max(latest.values()))
 
-    if outcomes_path:
-        outcomes = pd.read_parquet(outcomes_path)["outcome"]
-        table = summary_table(predictions, outcomes, threshold)
-        st.subheader("Model Diagnostics")
-        st.dataframe(table)
-
-    st.subheader("Latest Alerts")
-    ranking = pd.Series(latest).sort_values(ascending=False)
-    st.bar_chart(ranking)
-
+    outcomes: pd.Series | None = None
+    diagnostics: pd.DataFrame | None = None
     evidence = load_bayesian_evidence(prediction_path)
-    if evidence is not None:
-        st.subheader("Bayesian Evidence Snapshot")
-        st.dataframe(evidence)
+
+    if outcomes_path and Path(outcomes_path).exists():
+        outcomes = pd.read_parquet(outcomes_path)["outcome"]
+    elif using_sample:
+        outcomes = generate_sample_outcomes(predictions)
+
+    if outcomes is not None:
+        diagnostics = summary_table(predictions, outcomes, threshold)
+
+    if using_sample and (evidence is None or evidence.empty):
+        evidence = generate_sample_evidence(predictions)
+
+    render_dashboard(
+        predictions=predictions,
+        threshold=threshold,
+        outcomes=outcomes,
+        summary=diagnostics,
+        evidence=evidence,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/preact/dashboard/layout.py
+++ b/preact/dashboard/layout.py
@@ -1,0 +1,188 @@
+"""Reusable layout primitives for the PREACT Streamlit dashboard."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+import pandas as pd
+import streamlit as st
+
+
+@dataclass
+class AlertSummary:
+    country: str
+    probability: float
+    trend: float
+    sparkline: Iterable[float]
+
+    @property
+    def direction(self) -> str:
+        if self.trend > 0.02:
+            return "increasing"
+        if self.trend < -0.02:
+            return "decreasing"
+        return "stable"
+
+
+def predictions_to_frame(predictions: Dict[str, pd.Series]) -> pd.DataFrame:
+    """Combine a dict of series into a unified dataframe for plotting."""
+
+    frame = pd.DataFrame({name: series for name, series in predictions.items()})
+    frame.index.name = "date"
+    return frame
+
+
+def compute_alert_summaries(predictions: Dict[str, pd.Series], window: int = 7) -> list[AlertSummary]:
+    summaries: list[AlertSummary] = []
+    for country, series in predictions.items():
+        tail = series.tail(window)
+        trend = float(tail.iloc[-1] - tail.iloc[0]) if len(tail) >= 2 else 0.0
+        summaries.append(
+            AlertSummary(
+                country=country,
+                probability=float(series.iloc[-1]),
+                trend=trend,
+                sparkline=series.tail(20).tolist(),
+            )
+        )
+    summaries.sort(key=lambda alert: alert.probability, reverse=True)
+    return summaries
+
+
+def render_header(predictions: Dict[str, pd.Series]) -> None:
+    latest = {name: float(series.iloc[-1]) for name, series in predictions.items()}
+    highest_country = max(latest, key=latest.get)
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Countries monitored", len(predictions))
+    col2.metric("Highest alert probability", f"{latest[highest_country]*100:.1f}%", highest_country)
+
+    combined = predictions_to_frame(predictions)
+    rolling = combined.rolling(window=7).mean().iloc[-1].mean()
+    col3.metric("7-day rolling mean", f"{rolling*100:.1f}%")
+
+
+def render_alert_overview(predictions: Dict[str, pd.Series], threshold: float) -> None:
+    st.subheader("Alert overview")
+    summaries = compute_alert_summaries(predictions)
+    alerts_df = pd.DataFrame(
+        [
+            {
+                "Country": summary.country,
+                "Probability": summary.probability,
+                "Trend (Δ)": summary.trend,
+                "Status": summary.direction,
+            }
+            for summary in summaries
+        ]
+    )
+    alerts_df["Probability"] = alerts_df["Probability"].map(lambda value: f"{value*100:.1f}%")
+    alerts_df["Trend (Δ)"] = alerts_df["Trend (Δ)"].map(lambda value: f"{value*100:.1f}%")
+    alerts_df["Status"] = alerts_df["Status"].str.title()
+
+    st.dataframe(alerts_df, width="stretch", hide_index=True)
+
+    chart_data = predictions_to_frame(predictions)
+    highlighted = chart_data[[summary.country for summary in summaries[:5]]]
+    st.area_chart(highlighted, width="stretch")
+
+    st.caption(
+        f"Threshold set at {threshold*100:.0f}%. Alerts above this line require immediate review."
+    )
+
+
+def render_country_detail(predictions: Dict[str, pd.Series], default_country: str | None = None) -> None:
+    st.subheader("Country deep dive")
+    countries = sorted(predictions.keys())
+    default = default_country or countries[0]
+    country = st.selectbox("Select a country", options=countries, index=countries.index(default))
+    series = predictions[country]
+
+    cols = st.columns(2)
+    cols[0].metric("Latest probability", f"{series.iloc[-1]*100:.1f}%")
+    change = float(series.iloc[-1] - series.iloc[-8]) if len(series) > 7 else float(series.iloc[-1] - series.iloc[0])
+    cols[1].metric("7-day change", f"{change*100:.1f}%")
+
+    st.line_chart(series, width="stretch")
+
+    st.markdown(
+        """
+        **Interpretation guidance**
+
+        - Probabilities are model-derived and represent the chance of crisis escalation.
+        - Sudden increases signal the need for analyst review and potential response planning.
+        - Combine this signal with qualitative field reports before acting.
+        """
+    )
+
+
+def render_diagnostics(
+    predictions: Dict[str, pd.Series], outcomes: pd.Series | None, threshold: float, summary
+) -> None:
+    st.subheader("Model diagnostics")
+    if outcomes is None:
+        st.info("Upload observed outcomes to unlock precision and recall diagnostics.")
+        return
+
+    st.dataframe(summary, width="stretch")
+
+    comparison = pd.DataFrame(
+        {
+            "Probability": {country: float(series.iloc[-1]) for country, series in predictions.items()},
+            "Observed": outcomes.astype(float),
+        }
+    )
+    st.bar_chart(comparison, width="stretch")
+
+    st.caption(
+        "The chart contrasts the latest model probabilities with observed outcomes to help calibrate the threshold."
+        f" Current alert threshold: {threshold*100:.0f}%."
+    )
+
+
+def render_evidence(evidence: pd.DataFrame | None) -> None:
+    st.subheader("Evidence feed")
+    if evidence is None or evidence.empty:
+        st.info("No Bayesian evidence available yet. Once generated it will appear here with signal strength cues.")
+        return
+
+    st.dataframe(evidence, width="stretch")
+
+
+def render_dashboard(
+    predictions: Dict[str, pd.Series],
+    threshold: float,
+    outcomes: pd.Series | None = None,
+    summary: pd.DataFrame | None = None,
+    evidence: pd.DataFrame | None = None,
+) -> None:
+    render_header(predictions)
+    overview_tab, country_tab, diagnostics_tab, evidence_tab = st.tabs(
+        ["Overview", "Country detail", "Diagnostics", "Evidence"]
+    )
+
+    with overview_tab:
+        render_alert_overview(predictions, threshold)
+
+    with country_tab:
+        highest_country = max(predictions, key=lambda key: predictions[key].iloc[-1])
+        render_country_detail(predictions, default_country=highest_country)
+
+    with diagnostics_tab:
+        if summary is not None:
+            render_diagnostics(predictions, outcomes, threshold, summary)
+        else:
+            render_diagnostics(predictions, None, threshold, summary)
+
+    with evidence_tab:
+        render_evidence(evidence)
+
+
+__all__ = [
+    "render_dashboard",
+    "render_alert_overview",
+    "render_country_detail",
+    "render_diagnostics",
+    "render_evidence",
+]
+

--- a/preact/dashboard/sample_data.py
+++ b/preact/dashboard/sample_data.py
@@ -1,0 +1,74 @@
+"""Sample data generators for the PREACT dashboard UI MVP."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+COUNTRIES = [
+    "Nigeria",
+    "Ethiopia",
+    "South Sudan",
+    "Somalia",
+    "Democratic Republic of the Congo",
+    "Burkina Faso",
+]
+
+
+def _generate_time_index(days: int = 30) -> pd.DatetimeIndex:
+    """Return a date range ending today for the provided number of days."""
+
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=days - 1)
+    return pd.date_range(start=start, end=end, freq="D", name="date")
+
+
+def generate_sample_predictions() -> Dict[str, pd.Series]:
+    """Return a dictionary of country -> probability series for demo purposes."""
+
+    index = _generate_time_index()
+    rng = np.random.default_rng(seed=42)
+    predictions: Dict[str, pd.Series] = {}
+
+    for country in COUNTRIES:
+        base = rng.uniform(0.25, 0.65)
+        noise = rng.normal(0, 0.04, len(index)).cumsum()
+        series = np.clip(base + noise, 0.01, 0.99)
+        predictions[country] = pd.Series(series, index=index, name="probability")
+
+    return predictions
+
+
+def generate_sample_outcomes(predictions: Dict[str, pd.Series]) -> pd.Series:
+    """Create a binary outcome series that loosely follows the final probabilities."""
+
+    latest = {country: series.iloc[-1] for country, series in predictions.items()}
+    ordered = sorted(latest.items(), key=lambda item: item[1], reverse=True)
+    triggered = {country for country, prob in ordered[:2] if prob > 0.6}
+
+    outcomes = pd.Series({country: int(country in triggered) for country in latest.keys()}, name="outcome")
+    return outcomes
+
+
+def generate_sample_evidence(predictions: Dict[str, pd.Series]) -> pd.DataFrame:
+    """Create a Bayesian evidence-like summary table for demonstration."""
+
+    rng = np.random.default_rng(seed=24)
+    records = []
+    for country, series in predictions.items():
+        latest = float(series.iloc[-1])
+        signal_strength = rng.uniform(0.1, 0.9)
+        posterior_odds = latest / (1 - latest)
+        records.append(
+            {
+                "country": country,
+                "signal_strength": round(signal_strength, 2),
+                "posterior_odds": round(posterior_odds, 2),
+                "updated": series.index[-1].strftime("%Y-%m-%d"),
+            }
+        )
+
+    return pd.DataFrame.from_records(records)
+


### PR DESCRIPTION
## Summary
- modularize the Streamlit dashboard into a reusable layout layer with overview, country detail, diagnostics, and evidence tabs
- add deterministic sample data generators and integrate them into the app so the UX MVP can run without pipeline outputs
- update the Streamlit app to wire in the new architecture, handle fallbacks, and auto-load diagnostics when data is available

## Testing
- pytest *(fails: missing httpx dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e272071164832f9f449edf1cadf6a5