### PR TITLE
feat: add synthetic prediction pipeline

### DIFF
--- a/preact/dashboard/app.py
+++ b/preact/dashboard/app.py
@@ -1,13 +1,25 @@
 """Streamlit dashboard for the PREACT early warning system."""
 from __future__ import annotations
 
+import sys
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 import pandas as pd
 import streamlit as st
 
-from ..evaluation.metrics import summary_table
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = PACKAGE_ROOT.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from preact.evaluation.metrics import summary_table
+from preact.dashboard.layout import render_dashboard
+from preact.dashboard.sample_data import (
+    generate_sample_evidence,
+    generate_sample_outcomes,
+    generate_sample_predictions,
+)
 
 st.set_page_config(page_title="PREACT Early Warning", layout="wide")
 st.title("PREACT – Global Early Warning Dashboard")
@@ -18,8 +30,13 @@ def load_predictions(path: Path) -> Dict[str, pd.Series]:
 
     predictions: Dict[str, pd.Series] = {}
     for file in path.glob("*.parquet"):
-        series = pd.read_parquet(file)["probability"]
-        predictions[file.stem] = series
+        frame = pd.read_parquet(file)
+        series = frame["probability"]
+        if "country" in frame.columns:
+            name = str(frame["country"].iloc[0])
+        else:
+            name = file.stem.replace("_", " ").title()
+        predictions[name] = series
     return predictions
 
 
@@ -33,33 +50,51 @@ def load_bayesian_evidence(path: Path) -> pd.DataFrame | None:
     return frame
 
 
-def main(prediction_dir: str, outcomes_path: str | None = None) -> None:
-    st.sidebar.header("Data Inputs")
-    prediction_path = Path(prediction_dir)
-    predictions = load_predictions(prediction_path)
+def prepare_predictions(path: Path) -> Tuple[Dict[str, pd.Series], bool]:
+    """Load predictions or provide a deterministic sample fallback."""
 
-    if not predictions:
-        st.warning("No predictions found. Run the pipeline to generate outputs.")
-        return
+    predictions = load_predictions(path)
+    if predictions:
+        return predictions, False
+
+    sample_predictions = generate_sample_predictions()
+    return sample_predictions, True
+
+
+def main(prediction_dir: str, outcomes_path: str | None = None) -> None:
+    st.sidebar.header("Data inputs")
+    prediction_path = Path(prediction_dir)
+    predictions, using_sample = prepare_predictions(prediction_path)
+
+    if using_sample:
+        st.sidebar.warning(
+            "Nessun file di previsione trovato. Mostriamo dati di esempio per l'MVP."
+        )
 
     threshold = st.sidebar.slider("Alert threshold", min_value=0.1, max_value=0.9, value=0.65)
-    latest = {name: series.iloc[-1] for name, series in predictions.items()}
-    st.metric("Top Alert Probability", max(latest.values()))
 
-    if outcomes_path:
-        outcomes = pd.read_parquet(outcomes_path)["outcome"]
-        table = summary_table(predictions, outcomes, threshold)
-        st.subheader("Model Diagnostics")
-        st.dataframe(table)
-
-    st.subheader("Latest Alerts")
-    ranking = pd.Series(latest).sort_values(ascending=False)
-    st.bar_chart(ranking)
-
+    outcomes: pd.Series | None = None
+    diagnostics: pd.DataFrame | None = None
     evidence = load_bayesian_evidence(prediction_path)
-    if evidence is not None:
-        st.subheader("Bayesian Evidence Snapshot")
-        st.dataframe(evidence)
+
+    if outcomes_path and Path(outcomes_path).exists():
+        outcomes = pd.read_parquet(outcomes_path)["outcome"]
+    elif using_sample:
+        outcomes = generate_sample_outcomes(predictions)
+
+    if outcomes is not None:
+        diagnostics = summary_table(predictions, outcomes, threshold)
+
+    if using_sample and (evidence is None or evidence.empty):
+        evidence = generate_sample_evidence(predictions)
+
+    render_dashboard(
+        predictions=predictions,
+        threshold=threshold,
+        outcomes=outcomes,
+        summary=diagnostics,
+        evidence=evidence,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/preact/dashboard/layout.py
+++ b/preact/dashboard/layout.py
@@ -1,0 +1,188 @@
+"""Reusable layout primitives for the PREACT Streamlit dashboard."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+import pandas as pd
+import streamlit as st
+
+
+@dataclass
+class AlertSummary:
+    country: str
+    probability: float
+    trend: float
+    sparkline: Iterable[float]
+
+    @property
+    def direction(self) -> str:
+        if self.trend > 0.02:
+            return "increasing"
+        if self.trend < -0.02:
+            return "decreasing"
+        return "stable"
+
+
+def predictions_to_frame(predictions: Dict[str, pd.Series]) -> pd.DataFrame:
+    """Combine a dict of series into a unified dataframe for plotting."""
+
+    frame = pd.DataFrame({name: series for name, series in predictions.items()})
+    frame.index.name = "date"
+    return frame
+
+
+def compute_alert_summaries(predictions: Dict[str, pd.Series], window: int = 7) -> list[AlertSummary]:
+    summaries: list[AlertSummary] = []
+    for country, series in predictions.items():
+        tail = series.tail(window)
+        trend = float(tail.iloc[-1] - tail.iloc[0]) if len(tail) >= 2 else 0.0
+        summaries.append(
+            AlertSummary(
+                country=country,
+                probability=float(series.iloc[-1]),
+                trend=trend,
+                sparkline=series.tail(20).tolist(),
+            )
+        )
+    summaries.sort(key=lambda alert: alert.probability, reverse=True)
+    return summaries
+
+
+def render_header(predictions: Dict[str, pd.Series]) -> None:
+    latest = {name: float(series.iloc[-1]) for name, series in predictions.items()}
+    highest_country = max(latest, key=latest.get)
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Countries monitored", len(predictions))
+    col2.metric("Highest alert probability", f"{latest[highest_country]*100:.1f}%", highest_country)
+
+    combined = predictions_to_frame(predictions)
+    rolling = combined.rolling(window=7).mean().iloc[-1].mean()
+    col3.metric("7-day rolling mean", f"{rolling*100:.1f}%")
+
+
+def render_alert_overview(predictions: Dict[str, pd.Series], threshold: float) -> None:
+    st.subheader("Alert overview")
+    summaries = compute_alert_summaries(predictions)
+    alerts_df = pd.DataFrame(
+        [
+            {
+                "Country": summary.country,
+                "Probability": summary.probability,
+                "Trend (Δ)": summary.trend,
+                "Status": summary.direction,
+            }
+            for summary in summaries
+        ]
+    )
+    alerts_df["Probability"] = alerts_df["Probability"].map(lambda value: f"{value*100:.1f}%")
+    alerts_df["Trend (Δ)"] = alerts_df["Trend (Δ)"].map(lambda value: f"{value*100:.1f}%")
+    alerts_df["Status"] = alerts_df["Status"].str.title()
+
+    st.dataframe(alerts_df, width="stretch", hide_index=True)
+
+    chart_data = predictions_to_frame(predictions)
+    highlighted = chart_data[[summary.country for summary in summaries[:5]]]
+    st.area_chart(highlighted, width="stretch")
+
+    st.caption(
+        f"Threshold set at {threshold*100:.0f}%. Alerts above this line require immediate review."
+    )
+
+
+def render_country_detail(predictions: Dict[str, pd.Series], default_country: str | None = None) -> None:
+    st.subheader("Country deep dive")
+    countries = sorted(predictions.keys())
+    default = default_country or countries[0]
+    country = st.selectbox("Select a country", options=countries, index=countries.index(default))
+    series = predictions[country]
+
+    cols = st.columns(2)
+    cols[0].metric("Latest probability", f"{series.iloc[-1]*100:.1f}%")
+    change = float(series.iloc[-1] - series.iloc[-8]) if len(series) > 7 else float(series.iloc[-1] - series.iloc[0])
+    cols[1].metric("7-day change", f"{change*100:.1f}%")
+
+    st.line_chart(series, width="stretch")
+
+    st.markdown(
+        """
+        **Interpretation guidance**
+
+        - Probabilities are model-derived and represent the chance of crisis escalation.
+        - Sudden increases signal the need for analyst review and potential response planning.
+        - Combine this signal with qualitative field reports before acting.
+        """
+    )
+
+
+def render_diagnostics(
+    predictions: Dict[str, pd.Series], outcomes: pd.Series | None, threshold: float, summary
+) -> None:
+    st.subheader("Model diagnostics")
+    if outcomes is None:
+        st.info("Upload observed outcomes to unlock precision and recall diagnostics.")
+        return
+
+    st.dataframe(summary, width="stretch")
+
+    comparison = pd.DataFrame(
+        {
+            "Probability": {country: float(series.iloc[-1]) for country, series in predictions.items()},
+            "Observed": outcomes.astype(float),
+        }
+    )
+    st.bar_chart(comparison, width="stretch")
+
+    st.caption(
+        "The chart contrasts the latest model probabilities with observed outcomes to help calibrate the threshold."
+        f" Current alert threshold: {threshold*100:.0f}%."
+    )
+
+
+def render_evidence(evidence: pd.DataFrame | None) -> None:
+    st.subheader("Evidence feed")
+    if evidence is None or evidence.empty:
+        st.info("No Bayesian evidence available yet. Once generated it will appear here with signal strength cues.")
+        return
+
+    st.dataframe(evidence, width="stretch")
+
+
+def render_dashboard(
+    predictions: Dict[str, pd.Series],
+    threshold: float,
+    outcomes: pd.Series | None = None,
+    summary: pd.DataFrame | None = None,
+    evidence: pd.DataFrame | None = None,
+) -> None:
+    render_header(predictions)
+    overview_tab, country_tab, diagnostics_tab, evidence_tab = st.tabs(
+        ["Overview", "Country detail", "Diagnostics", "Evidence"]
+    )
+
+    with overview_tab:
+        render_alert_overview(predictions, threshold)
+
+    with country_tab:
+        highest_country = max(predictions, key=lambda key: predictions[key].iloc[-1])
+        render_country_detail(predictions, default_country=highest_country)
+
+    with diagnostics_tab:
+        if summary is not None:
+            render_diagnostics(predictions, outcomes, threshold, summary)
+        else:
+            render_diagnostics(predictions, None, threshold, summary)
+
+    with evidence_tab:
+        render_evidence(evidence)
+
+
+__all__ = [
+    "render_dashboard",
+    "render_alert_overview",
+    "render_country_detail",
+    "render_diagnostics",
+    "render_evidence",
+]
+

--- a/preact/dashboard/sample_data.py
+++ b/preact/dashboard/sample_data.py
@@ -1,0 +1,74 @@
+"""Sample data generators for the PREACT dashboard UI MVP."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+COUNTRIES = [
+    "Nigeria",
+    "Ethiopia",
+    "South Sudan",
+    "Somalia",
+    "Democratic Republic of the Congo",
+    "Burkina Faso",
+]
+
+
+def _generate_time_index(days: int = 30) -> pd.DatetimeIndex:
+    """Return a date range ending today for the provided number of days."""
+
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=days - 1)
+    return pd.date_range(start=start, end=end, freq="D", name="date")
+
+
+def generate_sample_predictions() -> Dict[str, pd.Series]:
+    """Return a dictionary of country -> probability series for demo purposes."""
+
+    index = _generate_time_index()
+    rng = np.random.default_rng(seed=42)
+    predictions: Dict[str, pd.Series] = {}
+
+    for country in COUNTRIES:
+        base = rng.uniform(0.25, 0.65)
+        noise = rng.normal(0, 0.04, len(index)).cumsum()
+        series = np.clip(base + noise, 0.01, 0.99)
+        predictions[country] = pd.Series(series, index=index, name="probability")
+
+    return predictions
+
+
+def generate_sample_outcomes(predictions: Dict[str, pd.Series]) -> pd.Series:
+    """Create a binary outcome series that loosely follows the final probabilities."""
+
+    latest = {country: series.iloc[-1] for country, series in predictions.items()}
+    ordered = sorted(latest.items(), key=lambda item: item[1], reverse=True)
+    triggered = {country for country, prob in ordered[:2] if prob > 0.6}
+
+    outcomes = pd.Series({country: int(country in triggered) for country in latest.keys()}, name="outcome")
+    return outcomes
+
+
+def generate_sample_evidence(predictions: Dict[str, pd.Series]) -> pd.DataFrame:
+    """Create a Bayesian evidence-like summary table for demonstration."""
+
+    rng = np.random.default_rng(seed=24)
+    records = []
+    for country, series in predictions.items():
+        latest = float(series.iloc[-1])
+        signal_strength = rng.uniform(0.1, 0.9)
+        posterior_odds = latest / (1 - latest)
+        records.append(
+            {
+                "country": country,
+                "signal_strength": round(signal_strength, 2),
+                "posterior_odds": round(posterior_odds, 2),
+                "updated": series.index[-1].strftime("%Y-%m-%d"),
+            }
+        )
+
+    return pd.DataFrame.from_records(records)
+

--- a/preact/pipeline/__init__.py
+++ b/preact/pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for running PREACT pipelines in constrained environments."""
+
+from .mvp import run_mvp_prediction_pipeline
+
+__all__ = ["run_mvp_prediction_pipeline"]

--- a/preact/pipeline/mvp.py
+++ b/preact/pipeline/mvp.py
@@ -1,0 +1,255 @@
+"""Synthetic MVP pipeline to produce model-ready predictions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+from ..config import FeatureConfig, ModelConfig, PREACTConfig
+from ..models.predictor import ModelOutput, PredictiveEngine
+
+DEFAULT_COUNTRIES = (
+    "Nigeria",
+    "Ethiopia",
+    "South Sudan",
+    "Somalia",
+    "Democratic Republic of the Congo",
+    "Burkina Faso",
+)
+
+
+@dataclass
+class PipelineArtifacts:
+    """Container for the main artefacts produced by the MVP pipeline."""
+
+    predictions: Dict[str, pd.Series]
+    outcomes: pd.Series
+    evidence: pd.DataFrame
+    model_outputs: list[ModelOutput]
+
+
+def _multi_index(dates: pd.DatetimeIndex, countries: Sequence[str]) -> pd.MultiIndex:
+    return pd.MultiIndex.from_product((dates, countries), names=["date", "country"])
+
+
+def _slugify(value: str) -> str:
+    return value.lower().replace(" ", "_")
+
+
+def _build_feature_frame(
+    values: Mapping[str, np.ndarray],
+    dates: pd.DatetimeIndex,
+    countries: Sequence[str],
+) -> pd.DataFrame:
+    index = _multi_index(dates, countries)
+    flattened: list[float] = []
+    for day in range(len(dates)):
+        for country in countries:
+            flattened.append(float(values[country][day]))
+    frame = pd.DataFrame({"value": flattened}, index=index)
+    return frame
+
+
+def _zscore(series: np.ndarray) -> np.ndarray:
+    std = float(series.std())
+    if std < 1e-6:
+        return np.zeros_like(series)
+    return (series - float(series.mean())) / std
+
+
+def generate_synthetic_training_data(
+    feature_configs: Iterable[FeatureConfig],
+    model_configs: Iterable[ModelConfig],
+    countries: Sequence[str] = DEFAULT_COUNTRIES,
+    days: int = 120,
+    seed: int = 7,
+) -> tuple[Dict[str, pd.DataFrame], pd.Series]:
+    """Create deterministic synthetic features and targets for MVP usage."""
+
+    rng = np.random.default_rng(seed)
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=days - 1)
+    dates = pd.date_range(start=start, end=end, freq="D")
+
+    per_country: Dict[str, Dict[str, np.ndarray]] = {country: {} for country in countries}
+    features: Dict[str, pd.DataFrame] = {}
+
+    base_intensity = {country: rng.uniform(0.2, 0.8) for country in countries}
+
+    for cfg in feature_configs:
+        domain = cfg.name.split("_", 1)[0]
+        feature_key = f"{domain}__{cfg.name}"
+        values: Dict[str, np.ndarray] = {}
+
+        for country in countries:
+            trend = rng.normal(0, 0.02, len(dates)).cumsum()
+            seasonal = 0.1 * np.sin(np.linspace(0, 3 * np.pi, len(dates)))
+            base = base_intensity[country]
+
+            if domain == "events":
+                lam = np.clip(base * 6 + trend + seasonal + rng.normal(0, 0.3, len(dates)), 0.2, None)
+                series = rng.poisson(lam=lam) + rng.binomial(1, 0.1, len(dates))
+            elif domain == "economic":
+                drift = rng.normal(0.0, 0.05)
+                series = base + drift + trend + seasonal + rng.normal(0, 0.05, len(dates))
+            elif domain == "humanitarian":
+                series = (
+                    base
+                    + 0.3 * trend
+                    + 0.2 * seasonal
+                    + rng.normal(0, 0.04, len(dates)).cumsum()
+                )
+            else:
+                series = base + trend + seasonal
+
+            # Ensure positive values for count-like series
+            series = np.clip(series, 0.0, None)
+            values[country] = series.astype(float)
+            per_country[country][feature_key] = values[country]
+
+        features[feature_key] = _build_feature_frame(values, dates, countries)
+
+    feature_names = {name for model in model_configs for name in model.features}
+    missing = feature_names - features.keys()
+    if missing:
+        raise KeyError(f"Synthetic generator missing features: {sorted(missing)}")
+
+    index = _multi_index(dates, countries)
+    target_values = np.zeros(len(index))
+
+    for day in range(len(dates)):
+        for country_idx, country in enumerate(countries):
+            offset = day * len(countries) + country_idx
+            events = per_country[country].get("events__events_coup_attempts")
+            violence = per_country[country].get("events__events_violence_against_civilians")
+            economic = per_country[country].get("economic__economic_pressure")
+            displacement = per_country[country].get(
+                "humanitarian__humanitarian_displacement_pressure"
+            )
+            constraints = per_country[country].get(
+                "humanitarian__humanitarian_operational_constraints"
+            )
+
+            stacked = np.stack(
+                [
+                    _zscore(events)[day] if events is not None else 0.0,
+                    _zscore(violence)[day] if violence is not None else 0.0,
+                    _zscore(economic)[day] if economic is not None else 0.0,
+                    _zscore(displacement)[day] if displacement is not None else 0.0,
+                    _zscore(constraints)[day] if constraints is not None else 0.0,
+                ]
+            )
+            score = 0.6 * stacked[0] + 0.5 * stacked[1] + 0.3 * stacked[3] + 0.2 * stacked[2] + 0.2 * stacked[4]
+            score += rng.normal(0, 0.4)
+            probability = 1.0 / (1.0 + np.exp(-score))
+            target_values[offset] = rng.binomial(1, probability)
+
+    target = pd.Series(target_values, index=index, name="event")
+    return features, target
+
+
+def combine_model_outputs(outputs: Iterable[ModelOutput]) -> Dict[str, pd.Series]:
+    """Average multiple model outputs into per-country probability series."""
+
+    stacked_frames: list[pd.DataFrame] = []
+    for output in outputs:
+        frame = output.probabilities.unstack("country")
+        stacked_frames.append(frame)
+
+    if not stacked_frames:
+        return {}
+
+    ensemble = sum(stacked_frames) / len(stacked_frames)
+    return {country: ensemble[country].rename("probability") for country in ensemble.columns}
+
+
+def build_evidence(predictions: Mapping[str, pd.Series]) -> pd.DataFrame:
+    """Generate deterministic evidence records from the predictions."""
+
+    records = []
+    for country, series in predictions.items():
+        if series.empty:
+            continue
+        latest = float(series.iloc[-1])
+        reference = float(series.iloc[-7]) if len(series) > 7 else float(series.iloc[0])
+        change = latest - reference
+        odds = latest / max(1e-3, 1 - latest)
+        records.append(
+            {
+                "country": country,
+                "signal_strength": round(float(np.clip(abs(change) * 4, 0.05, 0.95)), 2),
+                "posterior_odds": round(float(odds), 2),
+                "updated": series.index[-1].strftime("%Y-%m-%d"),
+            }
+        )
+    return pd.DataFrame.from_records(records)
+
+
+def save_predictions(predictions: Mapping[str, pd.Series], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for country, series in predictions.items():
+        frame = series.to_frame(name="probability")
+        frame["country"] = country
+        frame.to_parquet(output_dir / f"{_slugify(country)}.parquet")
+
+
+def save_outcomes(target: pd.Series, output_dir: Path) -> pd.Series:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest_date = target.index.get_level_values("date").max()
+    latest = target.xs(latest_date, level="date")
+    latest.name = "outcome"
+    latest.to_frame().to_parquet(output_dir / "outcomes.parquet")
+    return latest
+
+
+def save_evidence(evidence: pd.DataFrame, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    evidence.to_json(output_dir / "bayesian_evidence.json", orient="records", indent=2)
+
+
+def run_mvp_prediction_pipeline(
+    output_dir: Path,
+    config: PREACTConfig,
+    countries: Sequence[str] = DEFAULT_COUNTRIES,
+    days: int = 120,
+    seed: int = 7,
+) -> PipelineArtifacts:
+    """Train models on synthetic data and export country-level predictions."""
+
+    features, target = generate_synthetic_training_data(
+        config.features, config.models, countries=countries, days=days, seed=seed
+    )
+
+    engine = PredictiveEngine(config.models)
+    models = engine.train(features, target)
+    outputs = engine.predict(models, features, target)
+
+    predictions = combine_model_outputs(outputs)
+    save_predictions(predictions, output_dir / "predictions")
+
+    outcomes = save_outcomes(target, output_dir)
+    evidence = build_evidence(predictions)
+    save_evidence(evidence, output_dir / "predictions")
+
+    return PipelineArtifacts(
+        predictions=predictions,
+        outcomes=outcomes,
+        evidence=evidence,
+        model_outputs=list(outputs),
+    )
+
+
+__all__ = [
+    "PipelineArtifacts",
+    "build_evidence",
+    "combine_model_outputs",
+    "generate_synthetic_training_data",
+    "run_mvp_prediction_pipeline",
+    "save_evidence",
+    "save_outcomes",
+    "save_predictions",
+]


### PR DESCRIPTION
## Summary
- add a synthetic MVP pipeline module that fabricates feature tables, trains the existing models, and exports country-level predictions, outcomes, and evidence assets
- expose the pipeline helper via `preact.pipeline`, update the CLI to default to the synthetic mode, and add a flag for switching back to the live workflow
- teach the dashboard loader to recover readable country names from stored parquet files when present

## Testing
- python scripts/update_pipeline.py --output-dir data --mode synthetic --lookback-days 45
- pytest *(fails: missing httpx dependency required by starlette.testclient)*

------
https://chatgpt.com/codex/tasks/task_e_68e272071164832f9f449edf1cadf6a5