### PR TITLE
Add model persistence utilities and FastAPI stubs

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,0 +1,6 @@
+"""Lightweight FastAPI compatibility layer for test environments."""
+from __future__ import annotations
+
+from preact.backend._fastapi_stub import FastAPI, HTTPException, Query
+
+__all__ = ["FastAPI", "HTTPException", "Query"]

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -1,0 +1,6 @@
+"""Test client shim using the PREACT FastAPI stub."""
+from __future__ import annotations
+
+from preact.backend._fastapi_stub import TestClient
+
+__all__ = ["TestClient"]

--- a/preact/backend/__init__.py
+++ b/preact/backend/__init__.py
@@ -1,5 +1,15 @@
 """Backend entry points for the PREACT platform."""
 
-from .app import create_app
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["create_app"]
+
+
+def create_app(*args: Any, **kwargs: Any):
+    """Proxy to :func:`preact.backend.app.create_app` avoiding import cycles."""
+
+    from .app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)

--- a/preact/backend/_fastapi_stub.py
+++ b/preact/backend/_fastapi_stub.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 import inspect
 import types
-from typing import Any, Callable, Dict
-
-from pydantic import BaseModel
+from typing import Any, Callable, Dict, Mapping
 
 
 class _Response:
@@ -17,9 +15,9 @@ class _Response:
         return self._json
 
 
-def _prepare_kwargs(func: Callable[..., Any], params: Dict[str, Any] | None) -> Dict[str, Any]:
+def _prepare_kwargs(func: Callable[..., Any], params: Mapping[str, Any] | None) -> Dict[str, Any]:
     signature = inspect.signature(func)
-    params = params or {}
+    params = dict(params or {})
     kwargs: Dict[str, Any] = {}
     for name, parameter in signature.parameters.items():
         annotation = parameter.annotation
@@ -29,7 +27,7 @@ def _prepare_kwargs(func: Callable[..., Any], params: Dict[str, Any] | None) -> 
             isinstance(annotation, type)
             and any(
                 base.__name__ in {"BaseModel", "_BaseModel"}
-                for base in annotation.__mro__
+                for base in getattr(annotation, "__mro__", ())
             )
         ):
             kwargs[name] = annotation(**params)
@@ -52,62 +50,73 @@ def _prepare_kwargs(func: Callable[..., Any], params: Dict[str, Any] | None) -> 
     return kwargs
 
 
+class HTTPException(Exception):
+    """Lightweight HTTPException matching FastAPI's API surface."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def Query(default: Any = None, **_: Any) -> Any:  # noqa: N802 - mimic FastAPI signature
+    return default
+
+
+class FastAPI:
+    """Minimal FastAPI compatible application container."""
+
+    def __init__(self, title: str, version: str) -> None:
+        self.title = title
+        self.version = version
+        self.routes: Dict[tuple[str, str], Callable[..., Any]] = {}
+        self.state = types.SimpleNamespace()
+
+    def get(self, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.routes[("GET", path)] = func
+            return func
+
+        return decorator
+
+    def post(self, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.routes[("POST", path)] = func
+            return func
+
+        return decorator
+
+
+def _call_route(app: FastAPI, method: str, path: str, payload: Mapping[str, Any] | None) -> _Response:
+    try:
+        handler = app.routes[(method, path)]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=404, detail="Route not found") from exc
+    kwargs = _prepare_kwargs(handler, payload)
+    result = handler(**kwargs)
+    return _Response(result)
+
+
+class TestClient:
+    """Minimal synchronous test client compatible with FastAPI's interface."""
+
+    def __init__(self, app: FastAPI) -> None:
+        self.app = app
+
+    def get(self, path: str, params: Mapping[str, Any] | None = None) -> _Response:
+        return _call_route(self.app, "GET", path, params)
+
+    def post(self, path: str, json: Mapping[str, Any] | None = None) -> _Response:
+        return _call_route(self.app, "POST", path, json)
+
+
 def install_fastapi_stub() -> None:
-    """Install a lightweight FastAPI replacement into ``sys.modules``."""
+    """Install the stub FastAPI implementation into ``sys.modules``."""
 
     import sys
 
     if "fastapi" in sys.modules:  # pragma: no cover - defensive guard
         return
-
-    class HTTPException(Exception):
-        def __init__(self, status_code: int, detail: str) -> None:
-            super().__init__(detail)
-            self.status_code = status_code
-            self.detail = detail
-
-    def Query(default: Any = None, **_: Any) -> Any:  # noqa: N802 - mimic FastAPI API
-        return default
-
-    class FastAPI:
-        def __init__(self, title: str, version: str) -> None:
-            self.title = title
-            self.version = version
-            self.routes: Dict[tuple[str, str], Callable[..., Any]] = {}
-            self.state = types.SimpleNamespace()
-
-        def get(self, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-            def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-                self.routes[("GET", path)] = func
-                return func
-
-            return decorator
-
-        def post(self, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-            def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-                self.routes[("POST", path)] = func
-                return func
-
-            return decorator
-
-    def _call_route(app: FastAPI, method: str, path: str, payload: Dict[str, Any] | None) -> _Response:
-        try:
-            handler = app.routes[(method, path)]
-        except KeyError as exc:  # pragma: no cover - defensive guard
-            raise HTTPException(status_code=404, detail="Route not found") from exc
-        kwargs = _prepare_kwargs(handler, payload)
-        result = handler(**kwargs)
-        return _Response(result)
-
-    class TestClient:
-        def __init__(self, app: FastAPI) -> None:
-            self.app = app
-
-        def get(self, path: str, params: Dict[str, Any] | None = None) -> _Response:
-            return _call_route(self.app, "GET", path, params)
-
-        def post(self, path: str, json: Dict[str, Any] | None = None) -> _Response:
-            return _call_route(self.app, "POST", path, json)
 
     fastapi_module = types.ModuleType("fastapi")
     fastapi_module.FastAPI = FastAPI
@@ -119,3 +128,6 @@ def install_fastapi_stub() -> None:
 
     sys.modules["fastapi"] = fastapi_module
     sys.modules["fastapi.testclient"] = testclient_module
+
+
+__all__ = ["FastAPI", "HTTPException", "Query", "TestClient", "install_fastapi_stub"]

--- a/preact/feature_store/builder.py
+++ b/preact/feature_store/builder.py
@@ -1,8 +1,7 @@
-"""Feature engineering pipeline for PREACT."""
+"""Utilities for constructing PREACT's feature store."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Dict, Iterable, Mapping
 
 import pandas as pd
@@ -17,6 +16,8 @@ class FeatureStore:
     tables: Dict[str, pd.DataFrame]
 
     def latest(self) -> Dict[str, pd.Series]:
+        """Return the latest observation for each feature table."""
+
         return {name: df.iloc[-1] for name, df in self.tables.items() if not df.empty}
 
 
@@ -133,3 +134,11 @@ def build_feature_store(
             raise ValueError(f"Unsupported feature type: {cfg.name}")
     return combine_features(feature_groups=grouped_features)
 
+
+__all__ = [
+    "FeatureStore",
+    "aggregate_events",
+    "aggregate_humanitarian",
+    "build_feature_store",
+    "combine_features",
+]

--- a/preact/pipeline/mvp.py
+++ b/preact/pipeline/mvp.py
@@ -225,7 +225,12 @@ def run_mvp_prediction_pipeline(
     )
 
     engine = PredictiveEngine(config.models)
-    models = engine.train(features, target)
+    models_dir = config.storage.models_dir
+    if engine.has_persisted_models(models_dir):
+        models = engine.load_models(models_dir)
+    else:
+        models = engine.train(features, target)
+        engine.save_models(models, models_dir)
     outputs = engine.predict(models, features, target)
 
     predictions = combine_model_outputs(outputs)

--- a/tests/test_model_persistence.py
+++ b/tests/test_model_persistence.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from preact.config import ModelConfig
+from preact.models.neural import NeuralNetworkEngine
+from preact.models.predictor import PredictiveEngine
+
+
+def _sample_features() -> dict[str, pd.DataFrame]:
+    index = pd.date_range("2023-01-01", periods=8, freq="D")
+    return {
+        "events": pd.DataFrame(
+            {
+                "count": [5, 6, 8, 7, 9, 11, 12, 13],
+                "severity": [0.1, 0.12, 0.2, 0.22, 0.25, 0.3, 0.35, 0.4],
+            },
+            index=index,
+        ),
+        "economic": pd.DataFrame(
+            {
+                "gdp": [1.0, 1.05, 1.07, 1.1, 1.15, 1.17, 1.2, 1.25],
+                "inflation": [0.04, 0.05, 0.05, 0.06, 0.06, 0.07, 0.08, 0.09],
+            },
+            index=index,
+        ),
+    }
+
+
+def _sample_target() -> pd.Series:
+    return pd.Series(
+        [0, 0, 0, 0, 1, 1, 1, 1],
+        index=pd.date_range("2023-01-01", periods=8, freq="D"),
+        name="event",
+    )
+
+
+def test_predictive_engine_persistence(tmp_path):
+    config = ModelConfig(
+        name="thirty_day",
+        target="event",
+        horizon_days=30,
+        features=["events", "economic"],
+        hyperparameters={"n_estimators": 10, "max_depth": 2},
+    )
+    engine = PredictiveEngine([config])
+    features = _sample_features()
+    target = _sample_target()
+
+    models = engine.train(features, target)
+    engine.save_models(models, tmp_path)
+
+    assert engine.has_persisted_models(tmp_path)
+
+    loaded = engine.load_models(tmp_path)
+    original = engine.predict(models, features, target)[0].probabilities
+    restored = engine.predict(loaded, features, target)[0].probabilities
+
+    pd.testing.assert_series_equal(original, restored)
+
+
+def test_neural_engine_persistence(tmp_path):
+    config = ModelConfig(
+        name="atrocity_nn",
+        target="event",
+        horizon_days=60,
+        features=["events", "economic"],
+        hyperparameters={"hidden_layer_sizes": (4,), "max_iter": 50},
+    )
+    engine = NeuralNetworkEngine([config], random_state=5)
+    features = _sample_features()
+    target = _sample_target()
+
+    models = engine.train(features, target)
+    engine.save_models(models, tmp_path)
+
+    assert engine.has_persisted_models(tmp_path)
+
+    restored = engine.load_models(tmp_path)
+    assert config.name in engine.training_history
+
+    original = engine.predict(models, features, target)[0].probabilities
+    replay = engine.predict(restored, features, target)[0].probabilities
+
+    pd.testing.assert_series_equal(original, replay)


### PR DESCRIPTION
## Summary
- add lightweight FastAPI shim so the API layer can be tested without optional dependencies
- implement persistence helpers for predictive and neural engines and reuse them in the MVP pipeline
- rebuild the feature store builder imports and add regression tests for model persistence

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e27c21d5ec832fa0e7c8e41041a02d