### PR TITLE
Add MVP simulation engine and scenario builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Grazie a modelli di IA avanzati, la simulazione può **evolvere autonomamente**,
 - **Analisi automatica**: metriche di benessere, equità, sentiment sociale e stabilità economica.
 - **Scalabilità cloud**: dalla simulazione di una città fino a interi Paesi.
 
+### Moduli MVP
+Il progetto include ora un **motore di simulazione tick-based** allineato alla guida
+_building_map.md_. I componenti principali sono:
+
+- `policy_core`: applica aliquote, detrazioni e sussidi per calcolare redditi netti.
+- `economy_core`: aggiorna occupazione, consumi e indice dei prezzi in base alla domanda.
+- `sentiment_core`: sintetizza il sentiment socio-economico a partire da reddito, lavoro e inflazione.
+- `scenario_builder`: genera popolazione, imprese e shock sintetici con parametri riproducibili.
+- `simulation_engine`: orchestra i moduli core su un orizzonte mensile e produce KPI richiesti
+  (gettito, disoccupazione, Gini, sentiment, winners/losers).
+- `simulation_results`: fornisce utility per confronti A/B, esport e aggregazione dei KPI.
+
+Consulta `preact/simulation/` per maggiori dettagli e `tests/test_simulation.py` per esempi
+di utilizzo end-to-end.
+
 ### Use case principale: sandbox per le politiche pubbliche
 Il focus attuale del progetto è offrire a **ministeri, regioni e municipalità** un ambiente di prova completo per
 la **valutazione di riforme fiscali e pacchetti di welfare** prima della loro introduzione reale. Il workflow

--- a/preact/__init__.py
+++ b/preact/__init__.py
@@ -1,5 +1,7 @@
 """PREACT – Predictive Early-warning for Coups and Atrocities."""
-from .config import PREACTConfig
 
-__all__ = ["PREACTConfig"]
+from .config import PREACTConfig
+from . import simulation
+
+__all__ = ["PREACTConfig", "simulation"]
 

--- a/preact/simulation/__init__.py
+++ b/preact/simulation/__init__.py
@@ -1,0 +1,39 @@
+"""Simulation engine for PREACT MVP (v1).
+
+This package implements the high-level architecture outlined in
+``building_map.md``.  It provides a composable toolkit made of
+``policy_core``, ``economy_core`` and ``sentiment_core`` modules together with
+scenario building utilities and result summarisation helpers.
+"""
+
+from .engine import SimulationEngine, SimulationConfig
+from .policy import PolicyCore, PolicyParameters, TaxBracket
+from .economy import EconomyCore, EconomyParameters, EconomyState, Shock
+from .sentiment import SentimentCore, SentimentWeights
+from .scenario import (
+    Scenario,
+    ScenarioBuilder,
+    PopulationParameters,
+    FirmParameters,
+)
+from .results import SimulationResults, SimulationComparison
+
+__all__ = [
+    "SimulationEngine",
+    "SimulationConfig",
+    "PolicyCore",
+    "PolicyParameters",
+    "TaxBracket",
+    "EconomyCore",
+    "EconomyParameters",
+    "EconomyState",
+    "Shock",
+    "SentimentCore",
+    "SentimentWeights",
+    "Scenario",
+    "ScenarioBuilder",
+    "PopulationParameters",
+    "FirmParameters",
+    "SimulationResults",
+    "SimulationComparison",
+]

--- a/preact/simulation/economy.py
+++ b/preact/simulation/economy.py
@@ -1,0 +1,169 @@
+"""Economy core implementing simplified macro rules for the MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class EconomyParameters:
+    """Economy level parameters controlling behavioural rules."""
+
+    baseline_consumption: float
+    propensity_low_income: float = 0.85
+    propensity_high_income: float = 0.65
+    job_finding_rate: float = 0.08
+    job_separation_rate: float = 0.03
+    labour_demand_sensitivity: float = 0.4
+    price_sensitivity: float = 0.15
+    wage_growth: float = 0.01
+    unemployment_income: float = 600.0
+    base_wage: float = 1800.0
+    initial_cpi: float = 100.0
+
+
+@dataclass(frozen=True)
+class Shock:
+    """Represent an exogenous economic shock."""
+
+    name: str
+    intensity: float
+    start_tick: int = 0
+    end_tick: int | None = None
+
+    def is_active(self, tick: int) -> bool:
+        if tick < self.start_tick:
+            return False
+        if self.end_tick is None:
+            return True
+        return tick <= self.end_tick
+
+
+@dataclass
+class EconomyState:
+    """State variables tracked by the simulation engine."""
+
+    cpi: float
+    unemployment_rate: float
+    employment_rate: float
+    labour_demand_ratio: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "cpi": self.cpi,
+            "unemployment_rate": self.unemployment_rate,
+            "employment_rate": self.employment_rate,
+            "labour_demand_ratio": self.labour_demand_ratio,
+        }
+
+
+class EconomyCore:
+    """Encapsulate rules for employment, consumption and price dynamics."""
+
+    def __init__(self, parameters: EconomyParameters):
+        self.parameters = parameters
+
+    def compute_consumption(self, fiscal_frame: pd.DataFrame) -> pd.Series:
+        """Derive consumption from disposable income with heterogeneous MPC."""
+
+        disposable = fiscal_frame["disposable_income"].to_numpy()
+        median_income = float(np.median(disposable)) if len(disposable) else 0.0
+        prop_low = self.parameters.propensity_low_income
+        prop_high = self.parameters.propensity_high_income
+        propensity = np.where(disposable <= median_income, prop_low, prop_high)
+        consumption = disposable * propensity
+        return pd.Series(consumption, index=fiscal_frame.index, name="consumption")
+
+    def update_labour_market(
+        self,
+        population: pd.DataFrame,
+        consumption: pd.Series,
+        firms: pd.DataFrame,
+        tick: int,
+        shock: Optional[Shock] = None,
+    ) -> pd.DataFrame:
+        """Update employment statuses deterministically based on demand signals."""
+
+        frame = population.copy()
+        employed_mask = frame["employment_status"].str.lower().eq("employed")
+        unemployed_mask = ~employed_mask
+        employed = frame.loc[employed_mask]
+        unemployed = frame.loc[unemployed_mask]
+
+        demand_ratio = consumption.sum() / max(self.parameters.baseline_consumption, 1.0)
+        demand_ratio = float(np.clip(demand_ratio, 0.3, 1.7))
+
+        job_finding = self.parameters.job_finding_rate + self.parameters.labour_demand_sensitivity * (demand_ratio - 1.0)
+        job_separation = self.parameters.job_separation_rate - 0.5 * self.parameters.labour_demand_sensitivity * (demand_ratio - 1.0)
+
+        if shock and shock.is_active(tick):
+            if "energy" in shock.name.lower():
+                job_finding *= 1 - 0.7 * shock.intensity
+                job_separation *= 1 + 0.5 * shock.intensity
+            else:  # demand shock
+                job_finding *= 1 - 0.5 * shock.intensity
+                job_separation *= 1 + 0.3 * shock.intensity
+
+        job_finding = float(np.clip(job_finding, 0.0, 0.8))
+        job_separation = float(np.clip(job_separation, 0.0, 0.5))
+
+        hires = int(round(len(unemployed) * job_finding))
+        separations = int(round(len(employed) * job_separation))
+
+        capacity = int(firms.get("employment_capacity", pd.Series(dtype=float)).sum())
+        if capacity:
+            projected = len(employed) - separations + hires
+            if projected > capacity:
+                hires = max(0, hires - (projected - capacity))
+
+        if hires > 0 and not unemployed.empty:
+            to_hire = unemployed.sort_values("gross_income", ascending=False).head(hires).index
+            frame.loc[to_hire, "employment_status"] = "employed"
+            frame.loc[to_hire, "gross_income"] = np.maximum(
+                self.parameters.base_wage,
+                frame.loc[to_hire, "gross_income"],
+            ) * (1 + self.parameters.wage_growth)
+
+        if separations > 0 and not employed.empty:
+            to_fire = employed.sort_values("gross_income").head(separations).index
+            frame.loc[to_fire, "employment_status"] = "unemployed"
+            frame.loc[to_fire, "gross_income"] = self.parameters.unemployment_income
+
+        return frame
+
+    def update_state(
+        self,
+        population: pd.DataFrame,
+        consumption: pd.Series,
+        previous_state: EconomyState,
+        tick: int,
+        shock: Optional[Shock] = None,
+    ) -> EconomyState:
+        """Compute macro aggregates given the latest micro outcomes."""
+
+        demand_ratio = consumption.sum() / max(self.parameters.baseline_consumption, 1.0)
+        demand_ratio = float(np.clip(demand_ratio, 0.3, 2.0))
+        price_delta = self.parameters.price_sensitivity * (demand_ratio - 1.0)
+
+        if shock and shock.is_active(tick):
+            if "energy" in shock.name.lower():
+                price_delta += 0.4 * shock.intensity
+            else:
+                price_delta -= 0.2 * shock.intensity
+
+        new_cpi = max(40.0, previous_state.cpi * (1 + price_delta))
+
+        employed_mask = population["employment_status"].str.lower().eq("employed")
+        employment_rate = float(employed_mask.mean()) if len(population) else 0.0
+        unemployment_rate = float(1.0 - employment_rate)
+
+        return EconomyState(
+            cpi=new_cpi,
+            unemployment_rate=unemployment_rate,
+            employment_rate=employment_rate,
+            labour_demand_ratio=demand_ratio,
+        )

--- a/preact/simulation/engine.py
+++ b/preact/simulation/engine.py
@@ -1,0 +1,150 @@
+"""Tick-based simulation engine orchestrating the PREACT MVP modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+from .economy import EconomyCore, EconomyParameters, EconomyState
+from .policy import PolicyCore, PolicyParameters
+from .scenario import Scenario
+from .sentiment import SentimentCore
+
+
+@dataclass(frozen=True)
+class SimulationConfig:
+    """Simulation runtime parameters."""
+
+    horizon: int = 12
+    time_step: str = "month"
+    store_agent_history: bool = True
+
+
+class SimulationEngine:
+    """Coordinate the policy, economy and sentiment cores."""
+
+    def __init__(
+        self,
+        *,
+        simulation_config: Optional[SimulationConfig] = None,
+        policy_core: Optional[PolicyCore] = None,
+        economy_core: Optional[EconomyCore] = None,
+        sentiment_core: Optional[SentimentCore] = None,
+    ) -> None:
+        self.simulation_config = simulation_config
+        self._policy_core = policy_core
+        self._economy_core = economy_core
+        self._sentiment_core = sentiment_core
+
+    def _ensure_modules(self, policy: PolicyParameters, economy: EconomyParameters) -> tuple[PolicyCore, EconomyCore, SentimentCore]:
+        policy_core = self._policy_core or PolicyCore(policy)
+        economy_core = self._economy_core or EconomyCore(economy)
+        sentiment_core = self._sentiment_core or SentimentCore()
+        return policy_core, economy_core, sentiment_core
+
+    def run(self, scenario: Scenario) -> "SimulationResults":
+        """Execute the simulation for the provided scenario."""
+
+        config = self.simulation_config or scenario.simulation_config
+        policy_core, economy_core, sentiment_core = self._ensure_modules(scenario.policy, scenario.economy)
+
+        population = scenario.population.copy(deep=True)
+        population.set_index("agent_id", inplace=True, drop=False)
+        baseline_frame = policy_core.apply(population)
+        baseline_disposable = baseline_frame["disposable_income"].copy()
+
+        employment_rate = float(population["employment_status"].str.lower().eq("employed").mean())
+        state = EconomyState(
+            cpi=scenario.economy.initial_cpi,
+            unemployment_rate=1 - employment_rate,
+            employment_rate=employment_rate,
+            labour_demand_ratio=1.0,
+        )
+        previous_state: EconomyState | None = None
+
+        disposable_history = pd.Series(0.0, index=population.index)
+        consumption_history = pd.Series(0.0, index=population.index)
+        tax_history = pd.Series(0.0, index=population.index)
+        transfer_history = pd.Series(0.0, index=population.index)
+
+        timeline_records: list[dict[str, float]] = []
+
+        for tick in range(config.horizon):
+            fiscal_frame = policy_core.apply(population)
+            consumption = economy_core.compute_consumption(fiscal_frame)
+
+            disposable_history = disposable_history.add(fiscal_frame["disposable_income"], fill_value=0.0)
+            consumption_history = consumption_history.add(consumption, fill_value=0.0)
+            tax_history = tax_history.add(fiscal_frame["tax_liability"], fill_value=0.0)
+            transfer_history = transfer_history.add(fiscal_frame["transfers"], fill_value=0.0)
+
+            population = economy_core.update_labour_market(
+                population=population,
+                consumption=consumption,
+                firms=scenario.firms,
+                tick=tick,
+                shock=scenario.shock,
+            )
+            state = economy_core.update_state(
+                population=population,
+                consumption=consumption,
+                previous_state=state,
+                tick=tick,
+                shock=scenario.shock,
+            )
+
+            sentiment = sentiment_core.compute(
+                fiscal_frame["disposable_income"],
+                state=state,
+                previous_state=previous_state,
+                baseline_income=baseline_disposable.mean(),
+            )
+            previous_state = state
+
+            timeline_records.append(
+                {
+                    "tick": tick,
+                    "tax_revenue": float(fiscal_frame["tax_liability"].sum()),
+                    "transfer_spending": float(fiscal_frame["transfers"].sum()),
+                    "budget_balance": float(fiscal_frame["tax_liability"].sum() - fiscal_frame["transfers"].sum()),
+                    "unemployment_rate": state.unemployment_rate,
+                    "employment_rate": state.employment_rate,
+                    "consumption_total": float(consumption.sum()),
+                    "consumption_mean": float(consumption.mean()),
+                    "cpi": state.cpi,
+                    "sentiment": sentiment,
+                    "labour_demand_ratio": state.labour_demand_ratio,
+                }
+            )
+
+        average_disposable = disposable_history / config.horizon
+        average_consumption = consumption_history / config.horizon
+        final_disposable = fiscal_frame["disposable_income"].copy()
+
+        agent_metrics = pd.DataFrame(
+            {
+                "agent_id": population.index,
+                "baseline_disposable": baseline_disposable,
+                "average_disposable": average_disposable,
+                "final_disposable": final_disposable,
+                "average_consumption": average_consumption,
+                "total_taxes": tax_history,
+                "total_transfers": transfer_history,
+            }
+        )
+        agent_metrics["delta_disposable"] = agent_metrics["average_disposable"] - agent_metrics["baseline_disposable"]
+
+        timeline = pd.DataFrame(timeline_records)
+
+        from .results import SimulationResults  # local import to avoid circular dependency
+
+        return SimulationResults(
+            scenario_name=scenario.name,
+            policy=scenario.policy,
+            timeline=timeline,
+            agent_metrics=agent_metrics,
+            config=config,
+            metadata=scenario.metadata or {},
+        )

--- a/preact/simulation/policy.py
+++ b/preact/simulation/policy.py
@@ -1,0 +1,95 @@
+"""Policy core module implementing tax and transfer logic for the MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class TaxBracket:
+    """Represent a tax bracket with an upper income threshold."""
+
+    threshold: float
+    rate: float
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass validation
+        if self.threshold <= 0:
+            raise ValueError("Threshold must be positive")
+        if not 0 <= self.rate <= 1:
+            raise ValueError("Rate must be expressed as a share between 0 and 1")
+
+
+@dataclass(frozen=True)
+class PolicyParameters:
+    """Container holding tax and transfer policy knobs."""
+
+    tax_brackets: Iterable[TaxBracket]
+    base_deduction: float
+    child_subsidy: float
+    unemployment_benefit: float = 900.0
+
+    def as_dataframe(self) -> pd.DataFrame:
+        """Return a DataFrame describing tax brackets for reporting purposes."""
+
+        brackets = sorted(self.tax_brackets, key=lambda item: item.threshold)
+        data = {"threshold": [b.threshold for b in brackets], "rate": [b.rate for b in brackets]}
+        return pd.DataFrame(data)
+
+
+class PolicyCore:
+    """Apply policy parameters to compute net income, tax and transfers."""
+
+    REQUIRED_COLUMNS = {"gross_income", "employment_status"}
+
+    def __init__(self, parameters: PolicyParameters):
+        self.parameters = parameters
+        self._brackets = sorted(parameters.tax_brackets, key=lambda b: b.threshold)
+
+    def _compute_tax(self, taxable_income: np.ndarray) -> np.ndarray:
+        """Compute tax liabilities for a taxable income vector."""
+
+        tax_due = np.zeros_like(taxable_income)
+        lower_bound = 0.0
+        for bracket in self._brackets:
+            upper = bracket.threshold
+            mask = taxable_income > lower_bound
+            taxable_segment = np.clip(taxable_income - lower_bound, 0, upper - lower_bound)
+            tax_due = tax_due + mask * taxable_segment * bracket.rate
+            lower_bound = upper
+        # Handle open-ended bracket if the highest threshold < inf
+        if self._brackets:
+            top_threshold = self._brackets[-1].threshold
+            top_rate = self._brackets[-1].rate
+            mask_top = taxable_income > top_threshold
+            tax_due = tax_due + mask_top * (taxable_income - top_threshold) * top_rate
+        return tax_due
+
+    def apply(self, population: pd.DataFrame) -> pd.DataFrame:
+        """Return a frame with fiscal metrics for the provided population."""
+
+        missing = self.REQUIRED_COLUMNS - set(population.columns)
+        if missing:
+            raise KeyError(f"Population frame missing required columns: {sorted(missing)}")
+
+        frame = population.copy()
+        num_children = frame.get("num_children", pd.Series(0, index=frame.index))
+        household_deduction = self.parameters.base_deduction
+        taxable_income = np.clip(frame["gross_income"] - household_deduction, 0, None)
+        tax_due = self._compute_tax(taxable_income.to_numpy())
+        subsidies = num_children.to_numpy() * self.parameters.child_subsidy
+        unemployment_mask = frame["employment_status"].str.lower().eq("unemployed")
+        unemployment_transfers = unemployment_mask.to_numpy() * self.parameters.unemployment_benefit
+        total_transfers = subsidies + unemployment_transfers
+        net_income = frame["gross_income"].to_numpy() - tax_due + total_transfers
+
+        result = frame.assign(
+            tax_liability=tax_due,
+            transfers=total_transfers,
+            net_income=net_income,
+            disposable_income=np.maximum(net_income, 0.0),
+        )
+        return result

--- a/preact/simulation/results.py
+++ b/preact/simulation/results.py
@@ -1,0 +1,156 @@
+"""Simulation output utilities for PREACT MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from .policy import PolicyParameters
+
+if TYPE_CHECKING:  # pragma: no cover - type checking helpers
+    from .engine import SimulationConfig
+
+
+def _gini(values: pd.Series) -> float:
+    """Compute the Gini coefficient of a distribution."""
+
+    arr = values.to_numpy(dtype=float)
+    if len(arr) == 0:
+        return 0.0
+    if np.allclose(arr, 0):
+        return 0.0
+    sorted_arr = np.sort(arr)
+    index = np.arange(1, len(sorted_arr) + 1)
+    return float((2 * np.sum(index * sorted_arr) / (len(sorted_arr) * sorted_arr.sum())) - (len(sorted_arr) + 1) / len(sorted_arr))
+
+
+@dataclass
+class SimulationResults:
+    """Container exposing convenient accessors for simulation outputs."""
+
+    scenario_name: str
+    policy: PolicyParameters
+    timeline: pd.DataFrame
+    agent_metrics: pd.DataFrame
+    config: "SimulationConfig"
+    metadata: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        self.timeline = self.timeline.sort_values("tick").reset_index(drop=True)
+        frame = self.agent_metrics.copy()
+        if frame.index.name == "agent_id":
+            frame = frame.reset_index(drop=True)
+        self.agent_metrics = frame.sort_values("agent_id").reset_index(drop=True)
+
+    def kpis(self) -> Dict[str, object]:
+        """Return the minimum KPI set requested by the MVP blueprint."""
+
+        latest = self.timeline.iloc[-1]
+        consumption_deciles = self._consumption_by_decile()
+        sentiment_deciles = self._sentiment_by_decile()
+        winners = self.winners_losers()
+
+        return {
+            "scenario": self.scenario_name,
+            "tax_revenue": float(latest["tax_revenue"]),
+            "transfer_spending": float(latest["transfer_spending"]),
+            "budget_balance": float(latest["budget_balance"]),
+            "unemployment_rate": float(latest["unemployment_rate"]),
+            "employment_rate": float(latest["employment_rate"]),
+            "cpi": float(latest["cpi"]),
+            "sentiment": float(latest["sentiment"]),
+            "consumption_by_decile": consumption_deciles,
+            "sentiment_by_decile": sentiment_deciles,
+            "gini_pre": _gini(self.agent_metrics["baseline_disposable"]),
+            "gini_post": _gini(self.agent_metrics["average_disposable"]),
+            "winners_losers": winners,
+        }
+
+    def _consumption_by_decile(self) -> Dict[str, float]:
+        consumption = self.agent_metrics["average_consumption"]
+        if consumption.empty:
+            return {}
+        deciles = pd.qcut(consumption, 10, labels=False, duplicates="drop")
+        groups = consumption.groupby(deciles)
+        return {f"decile_{int(k)+1}": float(v) for k, v in groups.mean().items()}
+
+    def _sentiment_by_decile(self) -> Dict[str, float]:
+        disposable = self.agent_metrics["average_disposable"]
+        if disposable.empty:
+            return {}
+        deciles = pd.qcut(disposable, 10, labels=False, duplicates="drop")
+        mean_disposable = disposable.mean()
+        scores: Dict[str, float] = {}
+        for decile in sorted(deciles.dropna().unique()):
+            mask = deciles == decile
+            subset = disposable[mask]
+            delta = 0.0 if mean_disposable == 0 else (subset.mean() - mean_disposable) / mean_disposable
+            scores[f"decile_{int(decile)+1}"] = float(np.clip(55 + 100 * 0.4 * delta, 0, 100))
+        return scores
+
+    def winners_losers(self, clusters: int = 5) -> pd.DataFrame:
+        """Return a winners/losers table based on disposable income delta."""
+
+        delta = self.agent_metrics["delta_disposable"]
+        if delta.empty:
+            return pd.DataFrame(columns=["cluster", "mean_delta", "count"])
+        try:
+            bins = pd.qcut(delta, clusters, labels=False, duplicates="drop")
+        except ValueError:
+            bins = pd.Series(np.zeros(len(delta), dtype=int), index=delta.index)
+        summary = (
+            pd.DataFrame({"cluster": bins, "delta": delta})
+            .groupby("cluster")
+            .agg(mean_delta=("delta", "mean"), count=("delta", "size"))
+            .reset_index()
+        )
+        return summary
+
+    def to_frame(self) -> pd.DataFrame:
+        """Return a flattened frame combining timeline and agent-level aggregates."""
+
+        latest = self.timeline.iloc[-1]
+        data = {
+            "scenario": self.scenario_name,
+            "tax_revenue": latest["tax_revenue"],
+            "transfer_spending": latest["transfer_spending"],
+            "budget_balance": latest["budget_balance"],
+            "unemployment_rate": latest["unemployment_rate"],
+            "employment_rate": latest["employment_rate"],
+            "cpi": latest["cpi"],
+            "sentiment": latest["sentiment"],
+            "gini_pre": _gini(self.agent_metrics["baseline_disposable"]),
+            "gini_post": _gini(self.agent_metrics["average_disposable"]),
+        }
+        return pd.DataFrame([data])
+
+
+@dataclass
+class SimulationComparison:
+    """Pair of scenarios compared A/B style."""
+
+    base: SimulationResults
+    reform: SimulationResults
+
+    def delta(self) -> Dict[str, float]:
+        """Return headline differences between reform and base."""
+
+        base_kpis = self.base.kpis()
+        reform_kpis = self.reform.kpis()
+        deltas: Dict[str, float] = {}
+        for key in [
+            "tax_revenue",
+            "transfer_spending",
+            "budget_balance",
+            "unemployment_rate",
+            "employment_rate",
+            "cpi",
+            "sentiment",
+            "gini_pre",
+            "gini_post",
+        ]:
+            deltas[key] = float(reform_kpis[key]) - float(base_kpis[key])
+        return deltas

--- a/preact/simulation/scenario.py
+++ b/preact/simulation/scenario.py
@@ -1,0 +1,185 @@
+"""Scenario builder for PREACT MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional, TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from .economy import EconomyParameters, Shock
+from .policy import PolicyParameters
+
+
+@dataclass(frozen=True)
+class PopulationParameters:
+    """Parameters describing the synthetic households."""
+
+    size: int
+    income_mean: float
+    income_sigma: float
+    employment_rate: float
+    sector_shares: Mapping[str, float]
+    household_size_mean: float = 2.4
+    child_share: float = 0.45
+
+
+@dataclass(frozen=True)
+class FirmParameters:
+    """Parameters describing the synthetic firms."""
+
+    size: int
+    sector_shares: Mapping[str, float]
+    productivity_mean: float
+    productivity_sigma: float
+    employment_capacity_mean: float
+
+
+@dataclass
+class Scenario:
+    """Concrete scenario used by the simulation engine."""
+
+    name: str
+    policy: PolicyParameters
+    economy: EconomyParameters
+    population: pd.DataFrame
+    firms: pd.DataFrame
+    simulation_config: "SimulationConfig"
+    shock: Optional[Shock] = None
+    metadata: Dict[str, object] | None = None
+
+    def with_policy(self, policy: PolicyParameters, name: Optional[str] = None) -> "Scenario":
+        """Return a clone of the scenario with a different policy."""
+
+        return Scenario(
+            name=name or self.name,
+            policy=policy,
+            economy=self.economy,
+            population=self.population.copy(deep=True),
+            firms=self.firms.copy(deep=True),
+            simulation_config=self.simulation_config,
+            shock=self.shock,
+            metadata=dict(self.metadata or {}),
+        )
+
+
+class ScenarioBuilder:
+    """Build reproducible scenarios matching the MVP blueprint."""
+
+    def __init__(
+        self,
+        population_params: PopulationParameters,
+        firm_params: FirmParameters,
+        economy_params: EconomyParameters,
+        policy_params: PolicyParameters,
+        simulation_config: "SimulationConfig",
+        *,
+        shock: Optional[Shock] = None,
+        seed: int = 42,
+    ) -> None:
+        self.population_params = population_params
+        self.firm_params = firm_params
+        self.economy_params = economy_params
+        self.policy_params = policy_params
+        self.simulation_config = simulation_config
+        self.shock = shock
+        self.rng = np.random.default_rng(seed)
+        self._population_template = self._create_population()
+        self._firms_template = self._create_firms()
+
+    def _create_population(self) -> pd.DataFrame:
+        params = self.population_params
+        rng = self.rng
+        mu = np.log(params.income_mean) - 0.5 * params.income_sigma ** 2
+        incomes = rng.lognormal(mean=mu, sigma=params.income_sigma, size=params.size)
+        household_size = rng.poisson(lam=params.household_size_mean, size=params.size) + 1
+        has_children = rng.uniform(size=params.size) < params.child_share
+        num_children = rng.binomial(n=np.maximum(household_size - 1, 0), p=0.6, size=params.size)
+        num_children = np.where(has_children, num_children, 0)
+        employment_status = np.where(
+            rng.uniform(size=params.size) < params.employment_rate,
+            "employed",
+            "unemployed",
+        )
+        sectors = list(params.sector_shares.keys())
+        weights = np.array(list(params.sector_shares.values()), dtype=float)
+        weights = weights / weights.sum()
+        assigned_sector = rng.choice(sectors, p=weights, size=params.size)
+        propensity = np.where(incomes < np.median(incomes), 0.85, 0.65)
+        frame = pd.DataFrame(
+            {
+                "agent_id": np.arange(params.size),
+                "gross_income": incomes,
+                "household_size": household_size,
+                "num_children": num_children,
+                "employment_status": employment_status,
+                "sector": assigned_sector,
+                "propensity_to_consume": propensity,
+            }
+        )
+        return frame
+
+    def _create_firms(self) -> pd.DataFrame:
+        params = self.firm_params
+        rng = self.rng
+        sectors = list(params.sector_shares.keys())
+        weights = np.array(list(params.sector_shares.values()), dtype=float)
+        weights = weights / weights.sum()
+        sector_assign = rng.choice(sectors, p=weights, size=params.size)
+        productivity = rng.normal(loc=params.productivity_mean, scale=params.productivity_sigma, size=params.size)
+        expected_demand = rng.lognormal(mean=np.log(params.productivity_mean), sigma=0.4, size=params.size)
+        employment_capacity = np.maximum(
+            1,
+            rng.normal(loc=params.employment_capacity_mean, scale=params.employment_capacity_mean * 0.3, size=params.size),
+        ).astype(int)
+        return pd.DataFrame(
+            {
+                "firm_id": np.arange(params.size),
+                "sector": sector_assign,
+                "productivity": productivity,
+                "expected_demand": expected_demand,
+                "employment_capacity": employment_capacity,
+            }
+        )
+
+    def build(
+        self,
+        name: str = "Base",
+        *,
+        policy: Optional[PolicyParameters] = None,
+        shock: Optional[Shock] = None,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> Scenario:
+        """Return a scenario ready to be consumed by the simulation engine."""
+
+        population = self._population_template.copy(deep=True)
+        firms = self._firms_template.copy(deep=True)
+        return Scenario(
+            name=name,
+            policy=policy or self.policy_params,
+            economy=self.economy_params,
+            population=population,
+            firms=firms,
+            simulation_config=self.simulation_config,
+            shock=shock or self.shock,
+            metadata=metadata or {},
+        )
+
+    def refreshed(self) -> "ScenarioBuilder":
+        """Return a new builder with fresh draws keeping parameters constant."""
+
+        new_seed = int(self.rng.integers(0, 1_000_000))
+        return ScenarioBuilder(
+            population_params=self.population_params,
+            firm_params=self.firm_params,
+            economy_params=self.economy_params,
+            policy_params=self.policy_params,
+            simulation_config=self.simulation_config,
+            shock=self.shock,
+            seed=new_seed,
+        )
+
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from .engine import SimulationConfig

--- a/preact/simulation/sentiment.py
+++ b/preact/simulation/sentiment.py
@@ -1,0 +1,81 @@
+"""Sentiment core computing socio-economic mood indicators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from .economy import EconomyState
+
+
+@dataclass(frozen=True)
+class SentimentWeights:
+    """Weights used to aggregate socio-economic signals into a score."""
+
+    income: float = 0.45
+    employment: float = 0.35
+    inflation: float = 0.2
+    baseline: float = 55.0
+
+
+class SentimentCore:
+    """Compute sentiment indexes based on income, employment and inflation."""
+
+    def __init__(self, weights: SentimentWeights | None = None):
+        self.weights = weights or SentimentWeights()
+
+    def compute(
+        self,
+        disposable_income: pd.Series,
+        state: Optional[EconomyState] = None,
+        previous_state: Optional[EconomyState] = None,
+        baseline_income: Optional[float] = None,
+    ) -> float:
+        """Return a 0-100 sentiment score."""
+
+        income_mean = float(disposable_income.mean()) if len(disposable_income) else 0.0
+        if baseline_income is None:
+            baseline_income = income_mean
+        income_change = 0.0 if baseline_income == 0 else (income_mean - baseline_income) / baseline_income
+
+        employment_rate = state.employment_rate if state else 0.5
+        employment_change = 0.0
+        if state and previous_state:
+            employment_change = employment_rate - previous_state.employment_rate
+
+        inflation = state.cpi if state else 100.0
+        inflation_change = 0.0
+        if state and previous_state and previous_state.cpi:
+            inflation_change = (inflation - previous_state.cpi) / previous_state.cpi
+        elif not state:
+            inflation_change = 0.0
+        else:
+            inflation_change = (inflation - 100.0) / 100.0
+
+        weights = self.weights
+        score = (
+            weights.baseline
+            + 100 * (weights.income * income_change)
+            + 100 * (weights.employment * employment_change)
+            - 100 * (weights.inflation * inflation_change)
+        )
+        return float(np.clip(score, 0.0, 100.0))
+
+    def by_decile(self, disposable_income: pd.Series) -> pd.Series:
+        """Compute sentiment per income decile using dispersion-aware adjustments."""
+
+        if disposable_income.empty:
+            return pd.Series(dtype=float)
+        deciles = pd.qcut(disposable_income, 10, labels=False, duplicates="drop")
+        baseline = disposable_income.mean()
+        sentiments = []
+        for decile in sorted(deciles.dropna().unique()):
+            mask = deciles == decile
+            score = self.compute(disposable_income[mask], state=None, baseline_income=baseline)
+            sentiments.append((decile, score))
+        if not sentiments:
+            return pd.Series(dtype=float)
+        return pd.Series({decile: score for decile, score in sentiments}, name="sentiment_decile")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,137 @@
+"""Tests for the PREACT simulation stack."""
+
+from __future__ import annotations
+
+from preact.simulation import (
+    EconomyParameters,
+    FirmParameters,
+    PolicyParameters,
+    PopulationParameters,
+    ScenarioBuilder,
+    SimulationComparison,
+    SimulationConfig,
+    SimulationEngine,
+    TaxBracket,
+)
+
+
+def _build_policy() -> PolicyParameters:
+    brackets = [TaxBracket(threshold=30_000, rate=0.18), TaxBracket(threshold=75_000, rate=0.28)]
+    return PolicyParameters(tax_brackets=brackets, base_deduction=5_000, child_subsidy=120.0)
+
+
+def _build_economy(population_size: int, income_mean: float) -> EconomyParameters:
+    baseline_consumption = population_size * income_mean * 0.7
+    return EconomyParameters(baseline_consumption=baseline_consumption)
+
+
+def _build_population_params(population_size: int) -> PopulationParameters:
+    return PopulationParameters(
+        size=population_size,
+        income_mean=28_000,
+        income_sigma=0.6,
+        employment_rate=0.9,
+        sector_shares={"services": 0.6, "industry": 0.4},
+    )
+
+
+def _build_firm_params() -> FirmParameters:
+    return FirmParameters(
+        size=150,
+        sector_shares={"services": 0.6, "industry": 0.4},
+        productivity_mean=1.2,
+        productivity_sigma=0.3,
+        employment_capacity_mean=40,
+    )
+
+
+def test_scenario_builder_generates_expected_shapes() -> None:
+    policy = _build_policy()
+    population_params = _build_population_params(200)
+    economy_params = _build_economy(population_params.size, population_params.income_mean)
+    firm_params = _build_firm_params()
+    config = SimulationConfig(horizon=6)
+    builder = ScenarioBuilder(
+        population_params=population_params,
+        firm_params=firm_params,
+        economy_params=economy_params,
+        policy_params=policy,
+        simulation_config=config,
+        seed=123,
+    )
+
+    scenario = builder.build(name="TestScenario")
+    assert len(scenario.population) == population_params.size
+    assert {"gross_income", "employment_status", "num_children"}.issubset(scenario.population.columns)
+    assert len(scenario.firms) == firm_params.size
+
+    updated_policy = PolicyParameters(
+        tax_brackets=[TaxBracket(threshold=25_000, rate=0.2)],
+        base_deduction=6_000,
+        child_subsidy=150.0,
+    )
+    scenario_reform = scenario.with_policy(updated_policy, name="Reform")
+    assert scenario_reform.name == "Reform"
+    assert scenario_reform.policy is updated_policy
+    assert scenario_reform.population.equals(scenario.population)
+
+
+def test_simulation_engine_runs_and_returns_kpis() -> None:
+    population_params = _build_population_params(120)
+    policy = _build_policy()
+    economy_params = _build_economy(population_params.size, population_params.income_mean)
+    firm_params = _build_firm_params()
+    config = SimulationConfig(horizon=4)
+    builder = ScenarioBuilder(
+        population_params=population_params,
+        firm_params=firm_params,
+        economy_params=economy_params,
+        policy_params=policy,
+        simulation_config=config,
+        seed=321,
+    )
+    base_scenario = builder.build(name="Base")
+    reform_policy = PolicyParameters(
+        tax_brackets=[TaxBracket(threshold=35_000, rate=0.16), TaxBracket(threshold=80_000, rate=0.26)],
+        base_deduction=5_500,
+        child_subsidy=180.0,
+    )
+    reform_scenario = base_scenario.with_policy(reform_policy, name="Reform")
+
+    engine = SimulationEngine(simulation_config=config)
+    base_results = engine.run(base_scenario)
+    reform_results = engine.run(reform_scenario)
+
+    assert len(base_results.timeline) == config.horizon
+    assert len(reform_results.timeline) == config.horizon
+    assert len(base_results.agent_metrics) == population_params.size
+    assert "delta_disposable" in base_results.agent_metrics.columns
+
+    kpis = base_results.kpis()
+    for key in [
+        "tax_revenue",
+        "transfer_spending",
+        "budget_balance",
+        "unemployment_rate",
+        "employment_rate",
+        "cpi",
+        "sentiment",
+        "consumption_by_decile",
+        "gini_pre",
+        "gini_post",
+    ]:
+        assert key in kpis
+
+    comparison = SimulationComparison(base=base_results, reform=reform_results)
+    delta = comparison.delta()
+    assert set(delta.keys()) == {
+        "tax_revenue",
+        "transfer_spending",
+        "budget_balance",
+        "unemployment_rate",
+        "employment_rate",
+        "cpi",
+        "sentiment",
+        "gini_pre",
+        "gini_post",
+    }


### PR DESCRIPTION
## Summary
- implement the `preact.simulation` package with policy, economy, sentiment cores plus the tick-based engine and results helpers
- expose the new simulation stack in the public package namespace and describe the MVP modules in the README
- add pytest coverage for scenario building and engine KPIs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e283d97d44832f82044ee1401d7eea