### PR TITLE
Add fiscal workflow UI and reporting exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ _building_map.md_. I componenti principali sono:
 - `simulation_engine`: orchestra i moduli core su un orizzonte mensile e produce KPI richiesti
   (gettito, disoccupazione, Gini, sentiment, winners/losers).
 - `simulation_results`: fornisce utility per confronti A/B, esport e aggregazione dei KPI.
+- `dashboard`: flusso Streamlit **Config → Run → Results** con slider per policy, timeline A/B e pulsanti di download (CSV, Parquet, HTML, PDF).
+- `simulation/templates`: libreria di template territoriali ampliata (città media, area metropolitana, provincia rurale, distretto turistico).
 
 Consulta `preact/simulation/` per maggiori dettagli e `tests/test_simulation.py` per esempi
 di utilizzo end-to-end.

--- a/building_map.md
+++ b/building_map.md
@@ -57,9 +57,11 @@ Consentire a un utente **non tecnico** (policy analyst) di:
   - istogrammi per decili,
   - tabella winners/losers,
   - 2 grafici *Scenario vs Base* side-by-side.
+  - ✓ Implementato in `preact/dashboard/app.py` con flusso Config → Run → Results, slider policy e timeline A/B.
 - **Export:**
   - CSV/Parquet dei risultati,
   - Report HTML/PDF auto-generato (titolo, setup, grafici, takeaway, caveat).
+  - ✓ Report prodotti da `SimulationRepository.export(..., format="html"/"pdf")` con `preact/simulation/reporting.py`.
 
 ---
 
@@ -157,7 +159,8 @@ Consentire a un utente **non tecnico** (policy analyst) di:
 2. Implementare regole policy/economia base.  
 3. Runner + storage (FastAPI `/run`, DuckDB, Parquet).  
 4. Dashboard MVP (Streamlit: Config → Run → Results + export).  
-5. Template & demo (3 policy template + dataset seed; script `make demo`).  
+5. Template & demo (3 policy template + dataset seed; script `make demo`).
+   - ✓ Libreria template ampliata (`preact/simulation/templates.py`) con città media, regione metropolitana, provincia rurale e hub turistico.
 6. User test (task “trova winners/losers”; feedback; fix).  
 
 ---

--- a/preact/simulation/reporting.py
+++ b/preact/simulation/reporting.py
@@ -1,0 +1,224 @@
+"""Reporting utilities for exporting simulation results as HTML and PDF."""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .results import SimulationComparison, SimulationResults
+
+
+def _fig_to_base64(fig: plt.Figure) -> str:
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", bbox_inches="tight")
+    plt.close(fig)
+    buffer.seek(0)
+    return base64.b64encode(buffer.read()).decode("ascii")
+
+
+def _timeline_chart(
+    metric: str,
+    base: SimulationResults,
+    reform: SimulationResults | None = None,
+) -> tuple[str, plt.Figure]:
+    label = metric.replace("_", " ").title()
+    fig, ax = plt.subplots(figsize=(6, 3))
+    ax.plot(base.timeline["tick"], base.timeline[metric], label=f"Base – {base.scenario_name}")
+    if reform is not None:
+        ax.plot(
+            reform.timeline["tick"],
+            reform.timeline[metric],
+            label=f"Reform – {reform.scenario_name}",
+        )
+    ax.set_xlabel("Tick (month)")
+    ax.set_ylabel(label)
+    ax.set_title(f"{label} timeline")
+    ax.legend(loc="best")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    return label, fig
+
+
+def _winners_table(results: SimulationResults) -> pd.DataFrame:
+    winners = results.winners_losers()
+    winners["cluster"] = winners["cluster"].map(lambda value: f"Cluster {int(value) + 1}")
+    winners["mean_delta"] = winners["mean_delta"].map(lambda value: round(float(value), 2))
+    return winners
+
+
+def _kpi_pairs(
+    base: Dict[str, float],
+    comparison: Optional[Dict[str, float]] = None,
+) -> Iterable[str]:
+    tracked = [
+        "tax_revenue",
+        "transfer_spending",
+        "budget_balance",
+        "employment_rate",
+        "unemployment_rate",
+        "sentiment",
+        "gini_post",
+    ]
+    labels = {
+        "tax_revenue": "Gettito fiscale",
+        "transfer_spending": "Spesa trasferimenti",
+        "budget_balance": "Saldo PA",
+        "employment_rate": "Tasso occupazione",
+        "unemployment_rate": "Tasso disoccupazione",
+        "sentiment": "Sentiment medio",
+        "gini_post": "Indice di Gini (post)",
+    }
+    for key in tracked:
+        label = labels[key]
+        base_value = base.get(key)
+        if base_value is None:
+            continue
+        if comparison and key in comparison:
+            delta = comparison[key]
+            yield f"<li><strong>{label}</strong>: {base_value:.2f} (Δ riforma {delta:+.2f})</li>"
+        else:
+            yield f"<li><strong>{label}</strong>: {base_value:.2f}</li>"
+
+
+def build_html_report(
+    base: SimulationResults,
+    reform: SimulationResults | None = None,
+    comparison: SimulationComparison | None = None,
+) -> str:
+    """Generate an HTML report for a base run and optional reform."""
+
+    kpis = base.kpis()
+    comp_payload = comparison.delta() if comparison else None
+
+    charts: Dict[str, str] = {}
+    for metric in ["tax_revenue", "budget_balance", "sentiment"]:
+        label, fig = _timeline_chart(metric, base, reform)
+        charts[label] = _fig_to_base64(fig)
+
+    winners_table = _winners_table(base)
+    winners_html = winners_table.to_html(index=False, classes="winners-table")
+
+    reform_summary = (
+        "<p>Confronto attivo tra scenario base e riforma fiscale.</p>"
+        if reform is not None
+        else "<p>Nessuna riforma aggiuntiva selezionata.</p>"
+    )
+
+    kpi_lines = "\n".join(_kpi_pairs(kpis, comp_payload))
+
+    chart_images = "".join(
+        f'<div class="chart"><img src="data:image/png;base64,{data}" alt="{label}"/></div>'
+        for label, data in charts.items()
+    )
+
+    html = f"""
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <title>PREACT – Report fiscale</title>
+  <style>
+    body {{ font-family: 'Segoe UI', Arial, sans-serif; margin: 40px; color: #1f2933; }}
+    h1, h2 {{ color: #111827; }}
+    .summary {{ background: #f3f4f6; padding: 20px; border-radius: 12px; margin-bottom: 30px; }}
+    .charts {{ display: flex; flex-wrap: wrap; gap: 24px; }}
+    .chart {{ flex: 1 1 320px; border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px; background: #fff; }}
+    .chart img {{ width: 100%; height: auto; }}
+    .winners-table {{ border-collapse: collapse; width: 100%; margin-top: 16px; }}
+    .winners-table th, .winners-table td {{ border: 1px solid #d1d5db; padding: 8px 12px; text-align: left; }}
+    .winners-table th {{ background: #f9fafb; }}
+  </style>
+</head>
+<body>
+  <h1>PREACT – Report fiscale</h1>
+  <div class="summary">
+    <h2>Executive summary</h2>
+    <p>Scenario: <strong>{base.scenario_name}</strong></p>
+    {reform_summary}
+    <ul>
+      {kpi_lines}
+    </ul>
+  </div>
+  <h2>Timeline KPI</h2>
+  <div class="charts">
+    {chart_images}
+  </div>
+  <h2>Winners &amp; losers</h2>
+  {winners_html}
+</body>
+</html>
+"""
+    return html
+
+
+def build_pdf_report(
+    target: Path,
+    base: SimulationResults,
+    reform: SimulationResults | None = None,
+    comparison: SimulationComparison | None = None,
+) -> None:
+    """Persist a PDF report summarising the simulation results."""
+
+    from matplotlib.backends.backend_pdf import PdfPages
+
+    comparison_values = comparison.delta() if comparison else None
+
+    with PdfPages(target) as pdf:
+        fig, ax = plt.subplots(figsize=(8.27, 11.69))  # A4 portrait in inches
+        ax.axis("off")
+        lines = [
+            "PREACT – Report fiscale",
+            "",
+            f"Scenario base: {base.scenario_name}",
+        ]
+        if reform is not None:
+            lines.append(f"Scenario riforma: {reform.scenario_name}")
+        lines.append("")
+        for line in _kpi_pairs(base.kpis(), comparison_values):
+            lines.append(_strip_html(line))
+        text = "\n".join(lines)
+        ax.text(0.02, 0.98, text, va="top", ha="left", fontsize=10)
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        for metric in ["tax_revenue", "budget_balance", "sentiment"]:
+            _, fig = _timeline_chart(metric, base, reform)
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        winners = _winners_table(base)
+        fig, ax = plt.subplots(figsize=(8.27, 11.69))
+        ax.axis("off")
+        table = ax.table(
+            cellText=winners.values,
+            colLabels=winners.columns,
+            cellLoc="center",
+            loc="center",
+        )
+        table.scale(1, 1.5)
+        ax.set_title("Winners & losers", fontsize=12, pad=20)
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def _strip_html(value: str) -> str:
+    """Remove simple HTML tags used in the KPI bullet list."""
+
+    replacements = {
+        "<li>": "- ",
+        "</li>": "",
+        "<strong>": "",
+        "</strong>": "",
+    }
+    for src, dst in replacements.items():
+        value = value.replace(src, dst)
+    return value
+
+
+__all__ = ["build_html_report", "build_pdf_report"]
+

--- a/preact/simulation/templates.py
+++ b/preact/simulation/templates.py
@@ -98,6 +98,85 @@ def default_templates() -> Mapping[str, ScenarioTemplate]:
         unemployment_benefit=900.0,
     )
 
+    metro_population = PopulationParameters(
+        size=55000,
+        income_mean=36000.0,
+        income_sigma=0.7,
+        employment_rate=0.92,
+        sector_shares={"services": 0.78, "industry": 0.17, "technology": 0.05},
+        household_size_mean=2.4,
+        child_share=0.42,
+    )
+    metro_firms = FirmParameters(
+        size=2200,
+        sector_shares={"services": 0.55, "industry": 0.25, "technology": 0.2},
+        productivity_mean=1.35,
+        productivity_sigma=0.3,
+        employment_capacity_mean=58,
+    )
+    metro_policy = PolicyParameters(
+        tax_brackets=(
+            TaxBracket(threshold=25000, rate=0.16),
+            TaxBracket(threshold=55000, rate=0.24),
+            TaxBracket(threshold=110000, rate=0.33),
+        ),
+        base_deduction=4500.0,
+        child_subsidy=180.0,
+        unemployment_benefit=1000.0,
+    )
+
+    rural_population = PopulationParameters(
+        size=12000,
+        income_mean=22000.0,
+        income_sigma=0.45,
+        employment_rate=0.82,
+        sector_shares={"agriculture": 0.35, "services": 0.4, "industry": 0.25},
+        household_size_mean=3.1,
+        child_share=0.54,
+    )
+    rural_firms = FirmParameters(
+        size=380,
+        sector_shares={"agriculture": 0.45, "services": 0.35, "industry": 0.2},
+        productivity_mean=0.95,
+        productivity_sigma=0.18,
+        employment_capacity_mean=22,
+    )
+    rural_policy = PolicyParameters(
+        tax_brackets=(
+            TaxBracket(threshold=20000, rate=0.14),
+            TaxBracket(threshold=42000, rate=0.22),
+        ),
+        base_deduction=6000.0,
+        child_subsidy=220.0,
+        unemployment_benefit=780.0,
+    )
+
+    coastal_population = PopulationParameters(
+        size=32000,
+        income_mean=31000.0,
+        income_sigma=0.55,
+        employment_rate=0.88,
+        sector_shares={"services": 0.6, "industry": 0.25, "tourism": 0.15},
+        household_size_mean=2.8,
+        child_share=0.5,
+    )
+    coastal_firms = FirmParameters(
+        size=1100,
+        sector_shares={"services": 0.5, "industry": 0.2, "tourism": 0.3},
+        productivity_mean=1.12,
+        productivity_sigma=0.22,
+        employment_capacity_mean=33,
+    )
+    coastal_policy = PolicyParameters(
+        tax_brackets=(
+            TaxBracket(threshold=27000, rate=0.17),
+            TaxBracket(threshold=65000, rate=0.26),
+        ),
+        base_deduction=5200.0,
+        child_subsidy=165.0,
+        unemployment_benefit=850.0,
+    )
+
     templates: Dict[str, ScenarioTemplate] = {
         "medium_city": ScenarioTemplate(
             name="Medium City",
@@ -106,6 +185,33 @@ def default_templates() -> Mapping[str, ScenarioTemplate]:
             firms=medium_city_firms,
             economy=_baseline_economy(medium_city_population),
             policy=medium_city_policy,
+            horizon=12,
+        ),
+        "metropolitan_region": ScenarioTemplate(
+            name="Metropolitan Region",
+            description="Area metropolitana ad alta complessità settoriale e forte dinamismo occupazionale",
+            population=metro_population,
+            firms=metro_firms,
+            economy=_baseline_economy(metro_population),
+            policy=metro_policy,
+            horizon=18,
+        ),
+        "rural_province": ScenarioTemplate(
+            name="Rural Province",
+            description="Provincia rurale con redditi più bassi e forte dipendenza da sussidi familiari",
+            population=rural_population,
+            firms=rural_firms,
+            economy=_baseline_economy(rural_population),
+            policy=rural_policy,
+            horizon=12,
+        ),
+        "coastal_tourism": ScenarioTemplate(
+            name="Coastal Tourism Hub",
+            description="Distretto costiero orientato a servizi turistici con stagionalità marcata",
+            population=coastal_population,
+            firms=coastal_firms,
+            economy=_baseline_economy(coastal_population),
+            policy=coastal_policy,
             horizon=12,
         ),
     }

--- a/tests/test_simulation_storage.py
+++ b/tests/test_simulation_storage.py
@@ -64,6 +64,12 @@ def test_repository_store_and_fetch(tmp_path) -> None:
     assert exports["timeline"].exists()
     assert exports["agent_metrics"].exists()
 
+    html_report = repository.export(run_id, format="html")
+    assert html_report["report"].exists()
+
+    pdf_report = repository.export(run_id, format="pdf")
+    assert pdf_report["report"].exists()
+
 
 def test_simulation_service_runs_and_compares(tmp_path) -> None:
     repository = SimulationRepository(tmp_path / "service.duckdb", export_dir=tmp_path / "exports")
@@ -82,3 +88,10 @@ def test_simulation_service_runs_and_compares(tmp_path) -> None:
     assert summary.comparison is not None
     base_results = repository.fetch(summary.base_run_id)
     assert base_results.timeline.shape[0] == 3
+
+    report_with_comparison = repository.export(
+        summary.base_run_id,
+        format="html",
+        reform_run_id=summary.reform_run_id,
+    )
+    assert report_with_comparison["report"].exists()


### PR DESCRIPTION
## Summary
- replace the Streamlit prototype with a Config → Run → Results fiscal sandbox that exposes policy sliders, KPI cards, timelines and download buttons
- add HTML/PDF report generation utilities and broaden the seed template library to cover multiple territorial archetypes
- extend simulation exports, update documentation and refresh tests around the storage layer

## Testing
- pytest 【a390c2†L1-L37】【a390c2†L38-L56】
- pytest tests/test_simulation_storage.py 【da7798†L1-L12】

------
https://chatgpt.com/codex/tasks/task_e_68e2905e1e84832fbb128532acd4c18a