### PR TITLE
Align simulation module layout with docs

### DIFF
--- a/preact/simulation/economy_core.py
+++ b/preact/simulation/economy_core.py
@@ -1,0 +1,5 @@
+"""Compatibility layer exposing the economy core under the documented name."""
+
+from .economy import EconomyCore, EconomyParameters, EconomyState, Shock
+
+__all__ = ["EconomyCore", "EconomyParameters", "EconomyState", "Shock"]

--- a/preact/simulation/policy_core.py
+++ b/preact/simulation/policy_core.py
@@ -1,0 +1,10 @@
+"""Compatibility layer exposing the policy core under the documented name.
+
+The Markdown guides reference a ``policy_core`` module.  The functional
+implementation lives in :mod:`preact.simulation.policy`; this shim simply
+re-exports the public API so that both import paths are valid.
+"""
+
+from .policy import PolicyCore, PolicyParameters, TaxBracket
+
+__all__ = ["PolicyCore", "PolicyParameters", "TaxBracket"]

--- a/preact/simulation/scenario_builder.py
+++ b/preact/simulation/scenario_builder.py
@@ -1,0 +1,15 @@
+"""Compatibility layer exposing the scenario builder under the documented name."""
+
+from .scenario import (
+    Scenario,
+    ScenarioBuilder,
+    PopulationParameters,
+    FirmParameters,
+)
+
+__all__ = [
+    "Scenario",
+    "ScenarioBuilder",
+    "PopulationParameters",
+    "FirmParameters",
+]

--- a/preact/simulation/sentiment_core.py
+++ b/preact/simulation/sentiment_core.py
@@ -1,0 +1,5 @@
+"""Compatibility layer exposing the sentiment core under the documented name."""
+
+from .sentiment import SentimentCore, SentimentWeights
+
+__all__ = ["SentimentCore", "SentimentWeights"]

--- a/preact/simulation/simulation_engine.py
+++ b/preact/simulation/simulation_engine.py
@@ -1,0 +1,5 @@
+"""Compatibility layer exposing the simulation engine under the documented name."""
+
+from .engine import SimulationEngine, SimulationConfig
+
+__all__ = ["SimulationEngine", "SimulationConfig"]

--- a/preact/simulation/simulation_results.py
+++ b/preact/simulation/simulation_results.py
@@ -1,0 +1,5 @@
+"""Compatibility layer exposing simulation results under the documented name."""
+
+from .results import SimulationResults, SimulationComparison
+
+__all__ = ["SimulationResults", "SimulationComparison"]

--- a/preact/simulation/templates/__init__.py
+++ b/preact/simulation/templates/__init__.py
@@ -1,13 +1,24 @@
-"""Scenario templates reflecting the MVP blueprint from ``building_map.md``."""
+"""Scenario templates reflecting the MVP blueprint from ``building_map.md``.
+
+This package replaces the previous ``templates.py`` module so that the
+directory structure mirrors the references in the Markdown documentation
+(see ``README.md`` and ``building_map.md``).  The public API is intentionally
+kept identical: importing ``ScenarioTemplate`` or ``default_templates`` from
+``preact.simulation.templates`` continues to work as before while enabling the
+``simulation/templates`` path advertised in the docs.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Dict, Mapping
 
-from .economy import EconomyParameters
-from .policy import PolicyParameters, TaxBracket
-from .scenario import FirmParameters, PopulationParameters, ScenarioBuilder
-from .engine import SimulationConfig
+from ..economy import EconomyParameters
+from ..policy import PolicyParameters, TaxBracket
+from ..scenario import FirmParameters, PopulationParameters, ScenarioBuilder
+from ..engine import SimulationConfig
+
+__all__ = ["ScenarioTemplate", "default_templates"]
 
 
 @dataclass(frozen=True)
@@ -215,4 +226,5 @@ def default_templates() -> Mapping[str, ScenarioTemplate]:
             horizon=12,
         ),
     }
+
     return templates


### PR DESCRIPTION
## Summary
- move the simulation templates module into a package so the path matches the documentation
- add compatibility shim modules (policy_core, economy_core, sentiment_core, scenario_builder, simulation_engine, simulation_results) that mirror the documented import paths

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e2c49428c8832f816b11e66b8bc72f