### PR TITLE
Ensure Streamlit app prefers repository package

### DIFF
--- a/preact/dashboard/app.py
+++ b/preact/dashboard/app.py
@@ -13,7 +13,7 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ROOT = PACKAGE_ROOT.parent
 
 if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 import streamlit as st
 


### PR DESCRIPTION
## Summary
- ensure the Streamlit dashboard inserts the project root at the front of `sys.path` so the local `preact` package is imported even if other packages with the same name exist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c611ed80832f97ed534c75f2440d